### PR TITLE
feat(environment): implement create environment form

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -211,6 +211,18 @@
   gap: 0.85rem;
 }
 
+.environment-page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 0.8rem;
+}
+
+.environment-create-cta {
+  margin-top: 0;
+}
+
 .environment-card {
   border: 1px solid #d6e2f1;
   border-radius: 10px;
@@ -245,6 +257,62 @@
   font-size: 0.8rem;
   text-transform: capitalize;
   padding: 0.15rem 0.5rem;
+}
+
+.environment-created-notice {
+  margin-bottom: 0.95rem;
+  padding: 0.85rem 0.95rem;
+  border: 1px solid #86d19f;
+  border-radius: 10px;
+  background: #ecfbf1;
+  color: #1e4a2e;
+}
+
+.environment-created-notice p {
+  margin: 0;
+}
+
+.environment-created-detail {
+  margin-top: 0.5rem !important;
+}
+
+.environment-created-command-wrap {
+  margin-top: 0.55rem;
+}
+
+.environment-created-command {
+  margin: 0.35rem 0 0.75rem;
+  padding: 0.6rem 0.7rem;
+  border-radius: 8px;
+  border: 1px solid #b9d2f6;
+  background: #f5f9ff;
+  color: #17324a;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.environment-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  max-width: 560px;
+}
+
+.environment-textarea {
+  resize: vertical;
+}
+
+.environment-field-error {
+  margin: 0;
+  color: #b42318;
+  font-size: 0.9rem;
+}
+
+.environment-form-actions {
+  display: flex;
+  gap: 0.6rem;
+  margin-top: 0.4rem;
 }
 
 .async-state {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { AppShell } from './features/shell/AppShell'
 import { ShellPlaceholderPage } from './features/shell/ShellPlaceholderPage'
 import { ProtectedHomePage } from './features/auth/ProtectedHomePage'
 import { EnvironmentsPage } from './features/environments/EnvironmentsPage'
+import { CreateEnvironmentPage } from './features/environments/CreateEnvironmentPage'
 import './App.css'
 
 function App() {
@@ -18,6 +19,7 @@ function App() {
         <Route element={<AppShell />}>
           <Route path="/" element={<ProtectedHomePage />} />
           <Route path="/environments" element={<EnvironmentsPage />} />
+          <Route path="/environments/new" element={<CreateEnvironmentPage />} />
           <Route
             path="/benchmarks"
             element={

--- a/src/features/environments/CreateEnvironmentPage.tsx
+++ b/src/features/environments/CreateEnvironmentPage.tsx
@@ -1,0 +1,180 @@
+import { useState, type ChangeEvent, type FormEvent } from 'react'
+import { useNavigate } from 'react-router-dom'
+import type { EnvironmentDTOTypeEnum } from '../../generated/openapi/models/EnvironmentDTO'
+import { createEnvironment, CreateEnvironmentError } from './service'
+
+interface FormValues {
+  name: string
+  description: string
+  type: EnvironmentDTOTypeEnum
+}
+
+interface FormErrors {
+  name?: string
+  description?: string
+}
+
+function validate(values: FormValues): FormErrors {
+  const errors: FormErrors = {}
+
+  if (!values.name.trim()) {
+    errors.name = 'Environment name is required.'
+  } else if (values.name.trim().length < 3) {
+    errors.name = 'Environment name must be at least 3 characters.'
+  }
+
+  if (values.description.trim().length > 500) {
+    errors.description = 'Description must be 500 characters or fewer.'
+  }
+
+  return errors
+}
+
+export function CreateEnvironmentPage() {
+  const navigate = useNavigate()
+  const [values, setValues] = useState<FormValues>({
+    name: '',
+    description: '',
+    type: 'docker',
+  })
+  const [errors, setErrors] = useState<FormErrors>({})
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const handleChange =
+    (key: keyof FormValues) =>
+    (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+      const nextValue = event.target.value
+      setValues((prev) => ({ ...prev, [key]: nextValue }))
+      setErrors((prev) => ({ ...prev, [key]: undefined }))
+      setSubmitError(null)
+    }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const validation = validate(values)
+    setErrors(validation)
+    setSubmitError(null)
+
+    if (Object.keys(validation).length > 0) {
+      return
+    }
+
+    setIsSubmitting(true)
+    try {
+      const created = await createEnvironment({
+        name: values.name.trim(),
+        description: values.description.trim() || undefined,
+        type: values.type,
+      })
+
+      navigate('/environments', {
+        replace: true,
+        state: {
+          createdEnvironment: {
+            name: created.name,
+            token: created.token ?? null,
+            agentCommand: created.agentCommand ?? null,
+          },
+        },
+      })
+    } catch (error: unknown) {
+      if (error instanceof CreateEnvironmentError) {
+        setSubmitError(error.message)
+      } else {
+        setSubmitError('Unable to create environment right now.')
+      }
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <article className="shell-page">
+      <h1>Create environment</h1>
+      <p className="auth-text">
+        Create a new environment to onboard an agent and start benchmarking.
+      </p>
+
+      <form className="environment-form" onSubmit={handleSubmit} noValidate>
+        <label className="auth-label" htmlFor="environment-name">
+          Name
+        </label>
+        <input
+          id="environment-name"
+          className="auth-input"
+          value={values.name}
+          onChange={handleChange('name')}
+          aria-invalid={Boolean(errors.name)}
+          aria-describedby={errors.name ? 'environment-name-error' : undefined}
+          disabled={isSubmitting}
+        />
+        {errors.name ? (
+          <p id="environment-name-error" className="environment-field-error" role="alert">
+            {errors.name}
+          </p>
+        ) : null}
+
+        <label className="auth-label" htmlFor="environment-type">
+          Platform
+        </label>
+        <select
+          id="environment-type"
+          className="auth-input"
+          value={values.type}
+          onChange={handleChange('type')}
+          disabled={isSubmitting}
+        >
+          <option value="docker">Docker</option>
+          <option value="kubernetes">Kubernetes</option>
+        </select>
+
+        <label className="auth-label" htmlFor="environment-description">
+          Description (optional)
+        </label>
+        <textarea
+          id="environment-description"
+          className="auth-input environment-textarea"
+          value={values.description}
+          onChange={handleChange('description')}
+          aria-invalid={Boolean(errors.description)}
+          aria-describedby={
+            errors.description ? 'environment-description-error' : undefined
+          }
+          disabled={isSubmitting}
+          rows={4}
+        />
+        {errors.description ? (
+          <p
+            id="environment-description-error"
+            className="environment-field-error"
+            role="alert"
+          >
+            {errors.description}
+          </p>
+        ) : null}
+
+        {submitError ? (
+          <p className="auth-notice auth-notice-error" role="alert">
+            {submitError}
+          </p>
+        ) : null}
+
+        <div className="environment-form-actions">
+          <button type="submit" className="auth-button" disabled={isSubmitting}>
+            {isSubmitting ? 'Creating...' : 'Create environment'}
+          </button>
+          <button
+            type="button"
+            className="shell-alert-dismiss"
+            onClick={() => navigate('/environments')}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </article>
+  )
+}
+

--- a/src/features/environments/EnvironmentsPage.tsx
+++ b/src/features/environments/EnvironmentsPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
 import type { EnvironmentDTO } from '../../generated/openapi/models/EnvironmentDTO'
 import { AsyncStateView } from '../ui/async-state/AsyncState'
 import { EnvironmentsLoadError, listEnvironments } from './service'
@@ -20,9 +21,27 @@ function EnvironmentCard({ environment }: { environment: EnvironmentDTO }) {
 }
 
 export function EnvironmentsPage() {
+  const navigate = useNavigate()
+  const location = useLocation()
   const [items, setItems] = useState<Array<EnvironmentDTO>>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [createdNotice, setCreatedNotice] = useState<{
+    name: string
+    token: string | null
+    agentCommand: string | null
+  } | null>(() => {
+    const state = location.state as
+      | {
+          createdEnvironment?: {
+            name: string
+            token: string | null
+            agentCommand: string | null
+          }
+        }
+      | undefined
+    return state?.createdEnvironment ?? null
+  })
 
   const load = useCallback(async () => {
     setIsLoading(true)
@@ -53,10 +72,52 @@ export function EnvironmentsPage() {
 
   return (
     <article className="shell-page">
-      <h1>Environments</h1>
-      <p className="auth-text">
-        View all environments and pick one to manage services and benchmark runs.
-      </p>
+      <div className="environment-page-header">
+        <div>
+          <h1>Environments</h1>
+          <p className="auth-text">
+            View all environments and pick one to manage services and benchmark runs.
+          </p>
+        </div>
+        <button
+          type="button"
+          className="auth-button environment-create-cta"
+          onClick={() => navigate('/environments/new')}
+        >
+          Create environment
+        </button>
+      </div>
+
+      {createdNotice ? (
+        <section className="environment-created-notice" role="status">
+          <p>
+            <strong>{createdNotice.name}</strong> was created successfully.
+          </p>
+          {createdNotice.token ? (
+            <p className="environment-created-detail">
+              Agent token: <code>{createdNotice.token}</code>
+            </p>
+          ) : null}
+          {createdNotice.agentCommand ? (
+            <div className="environment-created-command-wrap">
+              <p className="environment-created-detail">Agent install command:</p>
+              <pre className="environment-created-command">
+                <code>{createdNotice.agentCommand}</code>
+              </pre>
+            </div>
+          ) : null}
+          <button
+            type="button"
+            className="shell-alert-dismiss"
+            onClick={() => {
+              setCreatedNotice(null)
+              navigate(location.pathname, { replace: true })
+            }}
+          >
+            Dismiss
+          </button>
+        </section>
+      ) : null}
 
       <AsyncStateView
         isLoading={isLoading}

--- a/src/features/environments/service.ts
+++ b/src/features/environments/service.ts
@@ -29,7 +29,7 @@ function readErrorMessage(
   }
 
   if (error.response.status >= 500) {
-    return `Server error while ${action === 'load' ? 'loading' : 'creating'} environment.`
+    return `Server error while ${action === 'load' ? 'loading environments' : 'creating environment'}.`
   }
 
   return `Unable to ${action === 'load' ? 'load environments' : 'create environment'} right now.`

--- a/src/features/environments/service.ts
+++ b/src/features/environments/service.ts
@@ -21,7 +21,7 @@ function readErrorMessage(
   action: 'load' | 'create',
 ): string {
   if (action === 'create' && error.response.status === 400) {
-    return 'Please fix the highlighted fields and try again.'
+    return 'There was a problem with your request. Please review the form and try again.'
   }
 
   if (error.response.status === 404) {

--- a/src/features/environments/service.ts
+++ b/src/features/environments/service.ts
@@ -9,16 +9,30 @@ export class EnvironmentsLoadError extends Error {
   }
 }
 
-async function readErrorMessage(error: ResponseError): Promise<string> {
+export class CreateEnvironmentError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'CreateEnvironmentError'
+  }
+}
+
+function readErrorMessage(
+  error: ResponseError,
+  action: 'load' | 'create',
+): string {
+  if (action === 'create' && error.response.status === 400) {
+    return 'Please fix the highlighted fields and try again.'
+  }
+
   if (error.response.status === 404) {
     return 'Environments endpoint was not found.'
   }
 
   if (error.response.status >= 500) {
-    return 'Server error while loading environments.'
+    return `Server error while ${action === 'load' ? 'loading' : 'creating'} environment.`
   }
 
-  return 'Unable to load environments right now.'
+  return `Unable to ${action === 'load' ? 'load environments' : 'create environment'} right now.`
 }
 
 export async function listEnvironments(): Promise<Array<EnvironmentDTO>> {
@@ -28,12 +42,32 @@ export async function listEnvironments(): Promise<Array<EnvironmentDTO>> {
     return await environmentApi.listEnvironments()
   } catch (error: unknown) {
     if (error instanceof ResponseError) {
-      const message = await readErrorMessage(error)
+      const message = readErrorMessage(error, 'load')
       throw new EnvironmentsLoadError(message)
     }
 
     throw new EnvironmentsLoadError(
       'Network error while loading environments. Please try again.',
+    )
+  }
+}
+
+type CreateEnvironmentInput = Pick<EnvironmentDTO, 'name' | 'description' | 'type'>
+
+export async function createEnvironment(
+  input: CreateEnvironmentInput,
+): Promise<EnvironmentDTO> {
+  const environmentApi = createEnvironmentApi()
+
+  try {
+    return await environmentApi.createEnvironment({ environmentDTO: input })
+  } catch (error: unknown) {
+    if (error instanceof ResponseError) {
+      throw new CreateEnvironmentError(readErrorMessage(error, 'create'))
+    }
+
+    throw new CreateEnvironmentError(
+      'Network error while creating environment. Please try again.',
     )
   }
 }


### PR DESCRIPTION
## Summary
- add typed createEnvironment service with actionable error handling
- implement /environments/new form with client validation and inline field errors
- support submit/loading/error states and cancel navigation
- on successful create, redirect to /environments and show returned agent token/install command
- add create-environment CTA from environments list

## Validation
- npm run lint (passes; existing generated OpenAPI warnings remain)
- npm run build (fails on known pre-existing generated OpenAPI TypeScript baseline errors, unchanged)

Fixes #7