### PR TITLE
feat(benchmark): benchmark details page with run lifecycle actions

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -386,6 +386,278 @@
   background: #f8c38a;
 }
 
+.benchmark-details-header {
+  margin-bottom: 0.35rem;
+}
+
+.benchmark-details-header-text-grid {
+  flex: 1;
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(320px, 1fr) minmax(360px, 1.15fr);
+  column-gap: 1rem;
+  row-gap: 0.15rem;
+  align-items: baseline;
+}
+
+.benchmark-details-main-heading {
+  margin: 0;
+}
+
+.benchmark-details-instructions-topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.7rem;
+  min-width: 0;
+}
+
+.benchmark-details-byline {
+  margin: 0;
+}
+
+.benchmark-details-instructions-byline {
+  margin: 0;
+}
+
+.benchmark-details-header-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  justify-content: flex-end;
+  margin-bottom: 0;
+}
+
+.benchmark-details-edit-action {
+  margin-top: 0;
+}
+
+.benchmark-details-edit-action:hover,
+.benchmark-details-edit-action:focus-visible {
+  background: #d9c7f2;
+  color: #4b196e;
+}
+
+.benchmark-details-start-action {
+  margin-top: 0;
+  background: #16a34a;
+}
+
+.benchmark-details-start-action:hover,
+.benchmark-details-start-action:focus-visible {
+  background: #15803d;
+}
+
+.benchmark-details-start-action:disabled,
+.benchmark-details-edit-action:disabled {
+  opacity: 1;
+  color: #0f172a;
+  background: #94a3b8;
+  border: 0;
+  box-shadow: none;
+}
+
+.benchmark-details-start-action:disabled:hover,
+.benchmark-details-start-action:disabled:focus-visible,
+.benchmark-details-edit-action:disabled:hover,
+.benchmark-details-edit-action:disabled:focus-visible {
+  color: #0f172a;
+  background: #94a3b8;
+}
+
+.benchmark-details-split-layout {
+  display: grid;
+  grid-template-columns: minmax(320px, 1fr) minmax(360px, 1.15fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.benchmark-details-instructions-heading {
+  margin: 0;
+  color: #1f3347;
+  font-size: 1.1rem;
+}
+
+.benchmark-details-main-column {
+  min-width: 0;
+}
+
+.benchmark-details-context-section {
+  margin: 0;
+  padding: 0.35rem 0 0.2rem;
+  border-top: 1px solid #dbe4ef;
+  border-bottom: 1px solid #dbe4ef;
+}
+
+.benchmark-details-context-grid {
+  margin-bottom: 0;
+  gap: 0.5rem 0.9rem;
+}
+
+.benchmark-details-context-grid .shell-context-value {
+  margin-top: 0.08rem;
+}
+
+.benchmark-details-context-grid > div {
+  padding: 0.2rem 0;
+}
+
+.benchmark-details-section {
+  margin-top: 1rem;
+}
+
+.benchmark-details-section h2 {
+  margin: 0 0 0.6rem;
+  color: #1f3347;
+}
+
+.benchmark-details-instructions-section {
+  margin-top: 0;
+}
+
+.benchmark-details-instructions-shell {
+  border-top: 1px solid #dbe4ef;
+  border-bottom: 1px solid #dbe4ef;
+  padding: 0.35rem 0 0.2rem;
+}
+
+.benchmark-details-code-block {
+  margin: 0;
+  background: #f8fbff;
+  color: #1f3347;
+  border-radius: 10px;
+  border: 1px solid #d6e2f1;
+  padding: 0.8rem;
+  overflow: auto;
+  font-size: 0.87rem;
+  line-height: 1.5;
+  max-height: 360px;
+}
+
+.benchmark-details-code-block code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  white-space: pre;
+}
+
+.benchmark-js-token-plain {
+  color: #1f3347;
+}
+
+.benchmark-js-token-keyword {
+  color: #1d4ed8;
+  font-weight: 600;
+}
+
+.benchmark-js-token-string {
+  color: #047857;
+}
+
+.benchmark-js-token-number {
+  color: #a16207;
+}
+
+.benchmark-js-token-comment {
+  color: #64748b;
+  font-style: italic;
+}
+
+.benchmark-details-runs-empty {
+  border-style: solid;
+}
+
+.benchmark-details-runs-table-wrap {
+  overflow-x: auto;
+}
+
+.benchmark-details-runs-table {
+  width: 100%;
+  border-collapse: collapse;
+  border: 1px solid #d6e2f1;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.benchmark-details-runs-table th,
+.benchmark-details-runs-table td {
+  text-align: left;
+  padding: 0.6rem 0.7rem;
+  border-bottom: 1px solid #e3ebf5;
+  color: #1f3347;
+  vertical-align: middle;
+}
+
+.benchmark-details-runs-table th {
+  background: #f3f8ff;
+  font-size: 0.88rem;
+}
+
+.benchmark-details-runs-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.benchmark-details-run-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.benchmark-run-action,
+.benchmark-run-delete-action,
+.benchmark-run-cancel-action {
+  margin: 0;
+}
+
+.benchmark-run-cancel-action {
+  background: #f59e0b;
+  color: #7c2d12;
+}
+
+.benchmark-run-cancel-action:hover,
+.benchmark-run-cancel-action:focus-visible {
+  background: #fbbf24;
+}
+
+.benchmark-action-success {
+  border: 1px solid #86d19f;
+  background: #ecfbf1;
+  color: #1e4a2e;
+}
+
+.benchmark-details-runs-section {
+  margin-top: 1.1rem;
+}
+
+@media (max-width: 1020px) {
+  .benchmark-details-header-text-grid {
+    grid-template-columns: 1fr;
+    row-gap: 0.3rem;
+  }
+
+  .benchmark-details-instructions-heading {
+    margin-top: 0.25rem;
+  }
+
+  .benchmark-details-instructions-topline {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.45rem;
+  }
+
+  .benchmark-details-header-actions {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .benchmark-details-split-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .benchmark-details-context-section {
+    margin-bottom: 0.1rem;
+  }
+}
+
 .shell-content {
   padding: 1.25rem;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -430,12 +430,14 @@
 
 .benchmark-details-edit-action {
   margin-top: 0;
+  background: #7c3aed;
+  color: #ffffff;
 }
 
 .benchmark-details-edit-action:hover,
 .benchmark-details-edit-action:focus-visible {
-  background: #d9c7f2;
-  color: #4b196e;
+  background: #6d28d9;
+  color: #ffffff;
 }
 
 .benchmark-details-start-action {

--- a/src/App.css
+++ b/src/App.css
@@ -420,6 +420,12 @@
   margin: 0;
 }
 
+.benchmark-details-blocked-reason {
+  margin: 0;
+  color: #475569;
+  font-size: 0.9rem;
+}
+
 .benchmark-details-header-actions {
   display: inline-flex;
   align-items: center;

--- a/src/App.css
+++ b/src/App.css
@@ -626,6 +626,14 @@
   background: #fbbf24;
 }
 
+.benchmark-run-action-reason {
+  margin: 0;
+  width: 100%;
+  text-align: right;
+  color: #475569;
+  font-size: 0.82rem;
+}
+
 .benchmark-action-success {
   border: 1px solid #86d19f;
   background: #ecfbf1;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { EnvironmentDetailsPage } from './features/environments/EnvironmentDetai
 import { BenchmarkFormPage } from './features/benchmarks/BenchmarkFormPage'
 import { BenchmarkRunMonitorPage } from './features/benchmarks/BenchmarkRunMonitorPage'
 import { BenchmarkRunResultsPage } from './features/benchmarks/BenchmarkRunResultsPage'
+import { BenchmarkDetailsPage } from './features/benchmarks/BenchmarkDetailsPage'
 import './App.css'
 
 function App() {
@@ -35,6 +36,10 @@ function App() {
           <Route
             path="/environments/:environmentId/benchmarks/:benchmarkId/edit"
             element={<BenchmarkFormPage />}
+          />
+          <Route
+            path="/environments/:environmentId/benchmarks/:benchmarkId"
+            element={<BenchmarkDetailsPage />}
           />
           <Route
             path="/environments/:environmentId/benchmarks/:benchmarkId/runs/:runId"

--- a/src/features/benchmarks/BenchmarkDetailsPage.tsx
+++ b/src/features/benchmarks/BenchmarkDetailsPage.tsx
@@ -243,10 +243,16 @@ export function BenchmarkDetailsPage() {
       ? 'A run is already active in this environment.'
       : undefined
   const hasBenchmarkActiveRun = runs.some((run) => isActiveRunStatus(run.status))
-  const isEditBlocked = hasBenchmarkActiveRun || !benchmarkId.trim()
+  const hasRunsLoadError = Boolean(runsError)
+  const isEditBlocked =
+    hasBenchmarkActiveRun || isLoading || hasRunsLoadError || !benchmarkId.trim()
   const editBlockedReason = hasBenchmarkActiveRun
     ? 'You cannot edit this benchmark while it has an active run.'
-    : undefined
+    : isLoading
+      ? 'Benchmark runs are still loading. Please wait before editing this benchmark.'
+      : hasRunsLoadError
+        ? 'Unable to verify benchmark run status right now, so editing is temporarily disabled.'
+        : undefined
 
   const instructionSource =
     instructions || '// No benchmark instructions were provided.'
@@ -384,7 +390,11 @@ export function BenchmarkDetailsPage() {
                   navigate(`/environments/${environmentId}/benchmarks/${benchmarkId}/edit`)
                 }
                 disabled={isEditBlocked}
-                title={editBlockedReason}
+                aria-describedby={
+                  isEditBlocked && editBlockedReason
+                    ? 'benchmark-edit-blocked-reason'
+                    : undefined
+                }
               >
                 Edit
               </button>
@@ -393,7 +403,11 @@ export function BenchmarkDetailsPage() {
                 className="auth-button benchmark-details-start-action"
                 onClick={() => void handleStartRun()}
                 disabled={isStartBlocked}
-                title={startBlockedReason}
+                aria-describedby={
+                  isStartBlocked && startBlockedReason
+                    ? 'benchmark-start-blocked-reason'
+                    : undefined
+                }
               >
                 {isStartingRun ? 'Starting...' : 'Start run'}
               </button>
@@ -408,6 +422,24 @@ export function BenchmarkDetailsPage() {
           <p className="auth-text benchmark-details-instructions-byline">
             These instructions are used when starting a new run for this benchmark.
           </p>
+          {isEditBlocked && editBlockedReason ? (
+            <p
+              id="benchmark-edit-blocked-reason"
+              className="auth-text benchmark-details-blocked-reason"
+              role="status"
+            >
+              Edit unavailable: {editBlockedReason}
+            </p>
+          ) : null}
+          {isStartBlocked && startBlockedReason ? (
+            <p
+              id="benchmark-start-blocked-reason"
+              className="auth-text benchmark-details-blocked-reason"
+              role="status"
+            >
+              Start run unavailable: {startBlockedReason}
+            </p>
+          ) : null}
         </div>
       </div>
 

--- a/src/features/benchmarks/BenchmarkDetailsPage.tsx
+++ b/src/features/benchmarks/BenchmarkDetailsPage.tsx
@@ -1,0 +1,581 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { getEnvironmentDetails } from '../environments/service'
+import { AsyncStateView } from '../ui/async-state/AsyncState'
+import {
+  BenchmarkRunsLoadError,
+  DeleteBenchmarkRunError,
+  deleteBenchmarkRun,
+  getBenchmark,
+  GetBenchmarkError,
+  listActiveEnvironmentRuns,
+  listBenchmarkRuns,
+  startBenchmark,
+  StartBenchmarkError,
+  stopBenchmarkRun,
+  StopBenchmarkRunError,
+} from './service'
+import {
+  BenchmarkRunDTOStatusEnum,
+  type BenchmarkRunDTO,
+} from '../../generated/openapi/models/BenchmarkRunDTO'
+import {
+  formatRunStatus,
+  formatRuntimeDuration,
+  formatTimestamp,
+} from './format'
+
+type JsTokenKind = 'plain' | 'keyword' | 'string' | 'number' | 'comment'
+
+type JsToken = {
+  kind: JsTokenKind
+  value: string
+}
+
+const JS_TOKEN_REGEX =
+  /(\/\/[^\r\n]*|\/\*[\s\S]*?\*\/|"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|`(?:\\.|[^`\\])*`|\b(?:await|break|case|catch|class|const|continue|default|do|else|export|extends|finally|for|function|if|import|let|new|return|switch|throw|try|var|while|async|from|of|in|true|false|null|undefined)\b|\b\d+(?:\.\d+)?\b)/g
+
+function tokenizeJavaScript(source: string): Array<JsToken> {
+  const tokens: Array<JsToken> = []
+  let cursor = 0
+
+  for (const match of source.matchAll(JS_TOKEN_REGEX)) {
+    const index = match.index ?? 0
+    const value = match[0]
+
+    if (index > cursor) {
+      tokens.push({ kind: 'plain', value: source.slice(cursor, index) })
+    }
+
+    let kind: JsTokenKind = 'keyword'
+    if (value.startsWith('//') || value.startsWith('/*')) {
+      kind = 'comment'
+    } else if (
+      value.startsWith('"') ||
+      value.startsWith("'") ||
+      value.startsWith('`')
+    ) {
+      kind = 'string'
+    } else if (/^\d/.test(value)) {
+      kind = 'number'
+    }
+
+    tokens.push({ kind, value })
+    cursor = index + value.length
+  }
+
+  if (cursor < source.length) {
+    tokens.push({ kind: 'plain', value: source.slice(cursor) })
+  }
+
+  return tokens
+}
+
+function isActiveRunStatus(status?: string): boolean {
+  return (
+    status === BenchmarkRunDTOStatusEnum.PendingStart ||
+    status === BenchmarkRunDTOStatusEnum.Started ||
+    status === BenchmarkRunDTOStatusEnum.PendingStop
+  )
+}
+
+function isCancellableRunStatus(status?: string): boolean {
+  return (
+    status === BenchmarkRunDTOStatusEnum.PendingStart ||
+    status === BenchmarkRunDTOStatusEnum.Started
+  )
+}
+
+function toStatusVariant(
+  status?: string,
+): 'pending' | 'running' | 'stopped' | 'success' | 'failed' | 'unknown' {
+  switch (status) {
+    case BenchmarkRunDTOStatusEnum.PendingStart:
+    case BenchmarkRunDTOStatusEnum.PendingStop:
+      return 'pending'
+    case BenchmarkRunDTOStatusEnum.Started:
+      return 'running'
+    case BenchmarkRunDTOStatusEnum.Stopped:
+      return 'stopped'
+    case BenchmarkRunDTOStatusEnum.Finished:
+      return 'success'
+    case BenchmarkRunDTOStatusEnum.Failed:
+      return 'failed'
+    default:
+      return 'unknown'
+  }
+}
+
+function formatEndedWithRuntime(run: BenchmarkRunDTO): string {
+  if (!run.finishedAt) {
+    return 'Not finished yet'
+  }
+
+  const startedAt = run.startedAt ?? run.createdAt
+  const endedAtLabel = formatTimestamp(run.finishedAt)
+  const runtime = formatRuntimeDuration(startedAt, run.finishedAt)
+
+  return runtime ? `${endedAtLabel} (${runtime})` : endedAtLabel
+}
+
+export function BenchmarkDetailsPage() {
+  const { environmentId = '', benchmarkId = '' } = useParams<{
+    environmentId: string
+    benchmarkId: string
+  }>()
+  const navigate = useNavigate()
+
+  const [environmentName, setEnvironmentName] = useState<string | null>(null)
+  const [benchmarkName, setBenchmarkName] = useState<string | null>(null)
+  const [description, setDescription] = useState('')
+  const [instructions, setInstructions] = useState('')
+  const [runs, setRuns] = useState<Array<BenchmarkRunDTO>>([])
+  const [activeRunsCount, setActiveRunsCount] = useState(0)
+  const [activeRunsError, setActiveRunsError] = useState<string | null>(null)
+  const [runsError, setRunsError] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [retryAttempt, setRetryAttempt] = useState(0)
+  const [isStartingRun, setIsStartingRun] = useState(false)
+  const [runActionInFlightById, setRunActionInFlightById] = useState<
+    Record<string, boolean>
+  >({})
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [actionNotice, setActionNotice] = useState<string | null>(null)
+
+  const load = useCallback(
+    async (signal: AbortSignal) => {
+      if (!environmentId.trim() || !benchmarkId.trim()) {
+        setError('Environment ID or benchmark ID is missing.')
+        setIsLoading(false)
+        return
+      }
+
+      setIsLoading(true)
+      setError(null)
+      setRunsError(null)
+      setActiveRunsError(null)
+
+      const [environmentResult, benchmarkResult, runsResult, activeRunsResult] =
+        await Promise.allSettled([
+          getEnvironmentDetails(environmentId, signal),
+          getBenchmark(environmentId, benchmarkId, signal),
+          listBenchmarkRuns(environmentId, benchmarkId, signal),
+          listActiveEnvironmentRuns(environmentId, signal),
+        ])
+
+      if (signal.aborted) {
+        return
+      }
+
+      if (environmentResult.status === 'fulfilled') {
+        setEnvironmentName(environmentResult.value.name?.trim() || environmentId)
+      } else {
+        setEnvironmentName(environmentId)
+      }
+
+      if (benchmarkResult.status === 'rejected') {
+        if (benchmarkResult.reason instanceof GetBenchmarkError) {
+          setError(benchmarkResult.reason.message)
+        } else {
+          setError('Unable to load benchmark details right now.')
+        }
+        setIsLoading(false)
+        return
+      }
+
+      const benchmark = benchmarkResult.value
+      setBenchmarkName(benchmark.name?.trim() || benchmarkId)
+      setDescription(benchmark.description?.trim() || '')
+      setInstructions(benchmark.k6Instructions?.trim() || '')
+
+      if (runsResult.status === 'fulfilled') {
+        setRuns(runsResult.value)
+      } else if (runsResult.reason instanceof BenchmarkRunsLoadError) {
+        setRunsError(runsResult.reason.message)
+        setRuns([])
+      } else {
+        setRunsError('Unable to load benchmark runs right now.')
+        setRuns([])
+      }
+
+      if (activeRunsResult.status === 'fulfilled') {
+        setActiveRunsCount(activeRunsResult.value.length)
+      } else if (activeRunsResult.reason instanceof BenchmarkRunsLoadError) {
+        setActiveRunsError(activeRunsResult.reason.message)
+        setActiveRunsCount(0)
+      } else {
+        setActiveRunsError('Unable to verify active runs right now.')
+        setActiveRunsCount(0)
+      }
+
+      setIsLoading(false)
+    },
+    [benchmarkId, environmentId],
+  )
+
+  useEffect(() => {
+    const controller = new AbortController()
+    void load(controller.signal)
+
+    return () => controller.abort()
+  }, [load, retryAttempt])
+
+  const sortedRuns = useMemo(
+    () =>
+      [...runs].sort((left, right) => {
+        const leftDate = new Date(
+          left.startedAt ?? left.createdAt ?? '1970-01-01T00:00:00.000Z',
+        ).getTime()
+        const rightDate = new Date(
+          right.startedAt ?? right.createdAt ?? '1970-01-01T00:00:00.000Z',
+        ).getTime()
+        return rightDate - leftDate
+      }),
+    [runs],
+  )
+
+  const isStartBlockedByActiveRun = activeRunsCount > 0
+  const isStartBlocked = isStartingRun || isStartBlockedByActiveRun || Boolean(activeRunsError)
+  const startBlockedReason = activeRunsError
+    ? 'Unable to verify active runs in this environment right now.'
+    : isStartBlockedByActiveRun
+      ? 'A run is already active in this environment.'
+      : undefined
+  const hasBenchmarkActiveRun = runs.some((run) => isActiveRunStatus(run.status))
+  const isEditBlocked = hasBenchmarkActiveRun || !benchmarkId.trim()
+  const editBlockedReason = hasBenchmarkActiveRun
+    ? 'You cannot edit this benchmark while it has an active run.'
+    : undefined
+
+  const instructionSource =
+    instructions || '// No benchmark instructions were provided.'
+  const instructionTokens = useMemo(
+    () => tokenizeJavaScript(instructionSource),
+    [instructionSource],
+  )
+
+  const setRunActionBusy = (runId: string, isBusy: boolean) => {
+    setRunActionInFlightById((current) => ({ ...current, [runId]: isBusy }))
+  }
+
+  const handleStartRun = async () => {
+    if (!environmentId.trim() || !benchmarkId.trim()) {
+      setActionError('Environment ID or benchmark ID is missing.')
+      return
+    }
+    if (isStartBlocked) {
+      return
+    }
+
+    setActionError(null)
+    setActionNotice(null)
+    setIsStartingRun(true)
+
+    try {
+      const started = await startBenchmark(environmentId, benchmarkId)
+      const runId = started.runId?.trim()
+      if (!runId) {
+        setActionError(
+          'Benchmark started, but run id was missing. Please refresh and try again.',
+        )
+        return
+      }
+
+      navigate(
+        `/environments/${environmentId}/benchmarks/${benchmarkId}/runs/${runId}`,
+      )
+    } catch (nextError: unknown) {
+      if (nextError instanceof StartBenchmarkError) {
+        setActionError(nextError.message)
+      } else {
+        setActionError('Unable to start benchmark right now.')
+      }
+    } finally {
+      setIsStartingRun(false)
+    }
+  }
+
+  const handleCancelRun = async (run: BenchmarkRunDTO) => {
+    const runId = run.id?.trim()
+    if (!runId) {
+      setActionError('Run id is missing and cannot be cancelled.')
+      return
+    }
+
+    if (!isCancellableRunStatus(run.status)) {
+      setActionError('This run is already stopping and cannot be cancelled again.')
+      return
+    }
+
+    const confirmed = window.confirm('Cancel this active run?')
+    if (!confirmed) {
+      return
+    }
+
+    setActionError(null)
+    setActionNotice(null)
+    setRunActionBusy(runId, true)
+
+    try {
+      await stopBenchmarkRun(environmentId, benchmarkId, runId)
+      setActionNotice('Run cancellation was requested.')
+      setRetryAttempt((current) => current + 1)
+    } catch (nextError: unknown) {
+      if (nextError instanceof StopBenchmarkRunError) {
+        setActionError(nextError.message)
+      } else {
+        setActionError('Unable to cancel benchmark run right now.')
+      }
+    } finally {
+      setRunActionBusy(runId, false)
+    }
+  }
+
+  const handleDeleteRun = async (run: BenchmarkRunDTO) => {
+    const runId = run.id?.trim()
+    if (!runId) {
+      setActionError('Run id is missing and cannot be deleted.')
+      return
+    }
+
+    const confirmed = window.confirm(
+      'Delete this run data permanently? This action cannot be undone.',
+    )
+    if (!confirmed) {
+      return
+    }
+
+    setActionError(null)
+    setActionNotice(null)
+    setRunActionBusy(runId, true)
+
+    try {
+      await deleteBenchmarkRun(environmentId, benchmarkId, runId)
+      setActionNotice('Run data was deleted.')
+      setRetryAttempt((current) => current + 1)
+    } catch (nextError: unknown) {
+      if (nextError instanceof DeleteBenchmarkRunError) {
+        setActionError(nextError.message)
+      } else {
+        setActionError('Unable to delete benchmark run right now.')
+      }
+    } finally {
+      setRunActionBusy(runId, false)
+    }
+  }
+
+  return (
+    <article className="shell-page">
+      <div className="benchmark-details-header">
+        <div className="benchmark-details-header-text-grid">
+          <h1 className="benchmark-details-main-heading">
+            {benchmarkName ?? 'Benchmark details'}
+          </h1>
+          <div className="benchmark-details-instructions-topline">
+            <h2 className="benchmark-details-instructions-heading">
+              Benchmark instructions
+            </h2>
+            <div className="benchmark-details-header-actions">
+              <button
+                type="button"
+                className="shell-alert-dismiss benchmark-details-edit-action"
+                onClick={() =>
+                  navigate(`/environments/${environmentId}/benchmarks/${benchmarkId}/edit`)
+                }
+                disabled={isEditBlocked}
+                title={editBlockedReason}
+              >
+                Edit
+              </button>
+              <button
+                type="button"
+                className="auth-button benchmark-details-start-action"
+                onClick={() => void handleStartRun()}
+                disabled={isStartBlocked}
+                title={startBlockedReason}
+              >
+                {isStartingRun ? 'Starting...' : 'Start run'}
+              </button>
+              <Link className="shell-alert-dismiss" to={`/environments/${environmentId}`}>
+                Back to environment
+              </Link>
+            </div>
+          </div>
+          <p className="auth-text benchmark-details-byline">
+            Inspect benchmark instructions and manage benchmark run lifecycle.
+          </p>
+          <p className="auth-text benchmark-details-instructions-byline">
+            These instructions are used when starting a new run for this benchmark.
+          </p>
+        </div>
+      </div>
+
+      <AsyncStateView
+        isLoading={isLoading}
+        error={error}
+        isEmpty={false}
+        onRetry={() => setRetryAttempt((current) => current + 1)}
+        loadingTitle="Loading benchmark details"
+      >
+        {actionError ? (
+          <p className="auth-notice auth-notice-error benchmark-action-error" role="alert">
+            {actionError}
+          </p>
+        ) : null}
+        {actionNotice ? (
+          <p className="auth-notice benchmark-action-success" role="status">
+            {actionNotice}
+          </p>
+        ) : null}
+        {activeRunsError ? (
+          <p className="auth-notice auth-notice-error benchmark-action-error" role="alert">
+            {activeRunsError}
+          </p>
+        ) : null}
+
+        <section className="benchmark-details-split-layout">
+          <div className="benchmark-details-main-column">
+            <section className="benchmark-details-context-section">
+              <section className="environment-detail-grid benchmark-details-context-grid">
+                <div>
+                  <p className="shell-context-label">Environment</p>
+                  <p className="shell-context-value">{environmentName ?? environmentId}</p>
+                </div>
+                <div>
+                  <p className="shell-context-label">Benchmark id</p>
+                  <p className="shell-context-value">{benchmarkId || 'n/a'}</p>
+                </div>
+                <div>
+                  <p className="shell-context-label">Description</p>
+                  <p className="shell-context-value">
+                    {description || 'No description provided.'}
+                  </p>
+                </div>
+                <div>
+                  <p className="shell-context-label">Active runs in environment</p>
+                  <p className="shell-context-value">
+                    {activeRunsError ? 'Unknown' : String(activeRunsCount)}
+                  </p>
+                </div>
+              </section>
+            </section>
+          </div>
+
+          <section className="benchmark-details-section benchmark-details-instructions-section">
+            <div className="benchmark-details-instructions-shell">
+              <pre className="benchmark-details-code-block">
+                <code>
+                  {instructionTokens.map((token, index) => (
+                    <span
+                      key={`${token.kind}-${index}`}
+                      className={`benchmark-js-token benchmark-js-token-${token.kind}`}
+                    >
+                      {token.value}
+                    </span>
+                  ))}
+                </code>
+              </pre>
+            </div>
+          </section>
+        </section>
+
+        <section className="benchmark-details-section benchmark-details-runs-section">
+          <h2>Runs</h2>
+          {runsError ? (
+            <p className="auth-notice auth-notice-error benchmark-action-error" role="alert">
+              {runsError}
+            </p>
+          ) : sortedRuns.length === 0 ? (
+            <section className="async-state async-state-empty benchmark-details-runs-empty">
+              <h2>No runs yet</h2>
+              <p>Start this benchmark to create the first run.</p>
+            </section>
+          ) : (
+            <div className="benchmark-details-runs-table-wrap">
+              <table className="benchmark-details-runs-table">
+                <thead>
+                  <tr>
+                    <th>Run start</th>
+                    <th>Run end / total</th>
+                    <th>Status</th>
+                    <th>Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sortedRuns.map((run, index) => {
+                    const runId = run.id?.trim() ?? ''
+                    const isRunActionBusy = Boolean(
+                      runId ? runActionInFlightById[runId] : false,
+                    )
+                    const isActive = isActiveRunStatus(run.status)
+                    const isCancelable = isCancellableRunStatus(run.status)
+                    const startedAt = run.startedAt ?? run.createdAt
+
+                    return (
+                      <tr key={runId || `benchmark-run-${index}`}>
+                        <td>{formatTimestamp(startedAt)}</td>
+                        <td>{formatEndedWithRuntime(run)}</td>
+                        <td>
+                          <span
+                            className={`benchmark-status-badge benchmark-status-${toStatusVariant(
+                              run.status,
+                            )}`}
+                          >
+                            {formatRunStatus(run.status)}
+                          </span>
+                        </td>
+                        <td>
+                          <div className="benchmark-details-run-actions">
+                            <button
+                              type="button"
+                              className="shell-alert-dismiss benchmark-run-action"
+                              onClick={() =>
+                                navigate(
+                                  `/environments/${environmentId}/benchmarks/${benchmarkId}/runs/${runId}`,
+                                )
+                              }
+                              disabled={!runId}
+                            >
+                              Run details
+                            </button>
+
+                            {isActive ? (
+                              <button
+                                type="button"
+                                className="auth-button benchmark-run-cancel-action"
+                                onClick={() => void handleCancelRun(run)}
+                                disabled={!runId || isRunActionBusy || !isCancelable}
+                                title={
+                                  !isCancelable
+                                    ? 'This run is already stopping.'
+                                    : undefined
+                                }
+                              >
+                                {isRunActionBusy ? 'Cancelling...' : 'Cancel run'}
+                              </button>
+                            ) : (
+                              <button
+                                type="button"
+                                className="shell-alert-dismiss benchmark-run-delete-action"
+                                onClick={() => void handleDeleteRun(run)}
+                                disabled={!runId || isRunActionBusy}
+                              >
+                                {isRunActionBusy ? 'Deleting...' : 'Delete run data'}
+                              </button>
+                            )}
+                          </div>
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+      </AsyncStateView>
+    </article>
+  )
+}
+

--- a/src/features/benchmarks/BenchmarkDetailsPage.tsx
+++ b/src/features/benchmarks/BenchmarkDetailsPage.tsx
@@ -542,6 +542,13 @@ export function BenchmarkDetailsPage() {
                     )
                     const isActive = isActiveRunStatus(run.status)
                     const isCancelable = isCancellableRunStatus(run.status)
+                    const cancelBlockedReason =
+                      isActive && !isCancelable
+                        ? 'This run is already stopping and cannot be cancelled again.'
+                        : undefined
+                    const cancelBlockedReasonId = cancelBlockedReason
+                      ? `benchmark-run-cancel-blocked-${runId ?? index}`
+                      : undefined
                     const startedAt = run.startedAt ?? run.createdAt
 
                     return (
@@ -573,19 +580,25 @@ export function BenchmarkDetailsPage() {
                             </button>
 
                             {isActive ? (
-                              <button
-                                type="button"
-                                className="auth-button benchmark-run-cancel-action"
-                                onClick={() => void handleCancelRun(run)}
-                                disabled={!runId || isRunActionBusy || !isCancelable}
-                                title={
-                                  !isCancelable
-                                    ? 'This run is already stopping.'
-                                    : undefined
-                                }
-                              >
-                                {isRunActionBusy ? 'Cancelling...' : 'Cancel run'}
-                              </button>
+                              <>
+                                <button
+                                  type="button"
+                                  className="auth-button benchmark-run-cancel-action"
+                                  onClick={() => void handleCancelRun(run)}
+                                  disabled={!runId || isRunActionBusy || !isCancelable}
+                                  aria-describedby={cancelBlockedReasonId}
+                                >
+                                  {isRunActionBusy ? 'Cancelling...' : 'Cancel run'}
+                                </button>
+                                {cancelBlockedReasonId ? (
+                                  <p
+                                    id={cancelBlockedReasonId}
+                                    className="auth-text benchmark-run-action-reason"
+                                  >
+                                    {cancelBlockedReason}
+                                  </p>
+                                ) : null}
+                              </>
                             ) : (
                               <button
                                 type="button"

--- a/src/features/benchmarks/service.ts
+++ b/src/features/benchmarks/service.ts
@@ -288,6 +288,11 @@ export async function stopBenchmarkRun(
           'This run is not in a stoppable state right now.',
         )
       }
+      if (error.response.status === 409) {
+        throw new StopBenchmarkRunError(
+          'This run is already stopping and cannot be cancelled again.',
+        )
+      }
       if (error.response.status === 404) {
         throw new StopBenchmarkRunError('Benchmark run was not found.')
       }

--- a/src/features/benchmarks/service.ts
+++ b/src/features/benchmarks/service.ts
@@ -1,6 +1,7 @@
 import { ResponseError } from '../../generated/openapi/runtime'
 import type { BenchmarkDTO } from '../../generated/openapi/models/BenchmarkDTO'
 import type { BenchmarkRunDerivedDTO } from '../../generated/openapi/models/BenchmarkRunDerivedDTO'
+import type { BenchmarkRunDTO } from '../../generated/openapi/models/BenchmarkRunDTO'
 import type { BenchmarkRunRawDTO } from '../../generated/openapi/models/BenchmarkRunRawDTO'
 import type { BenchmarkStatusDTO } from '../../generated/openapi/models/BenchmarkStatusDTO'
 import {
@@ -59,6 +60,13 @@ export class StopBenchmarkRunError extends Error {
   constructor(message: string) {
     super(message)
     this.name = 'StopBenchmarkRunError'
+  }
+}
+
+export class DeleteBenchmarkRunError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'DeleteBenchmarkRunError'
   }
 }
 
@@ -295,6 +303,44 @@ export async function stopBenchmarkRun(
   }
 }
 
+export async function deleteBenchmarkRun(
+  environmentId: string,
+  benchmarkId: string,
+  runId: string,
+): Promise<void> {
+  const runsApi = createBenchmarkRunsApi()
+
+  try {
+    await runsApi.deleteBenchmarkRun({ environmentId, benchmarkId, runId })
+  } catch (error: unknown) {
+    if (error instanceof ResponseError) {
+      if (error.response.status === 400) {
+        throw new DeleteBenchmarkRunError(
+          'This run cannot be deleted in its current state.',
+        )
+      }
+      if (error.response.status === 404) {
+        throw new DeleteBenchmarkRunError('Benchmark run was not found.')
+      }
+      if (error.response.status === 409) {
+        throw new DeleteBenchmarkRunError(
+          'Active runs cannot be deleted. Cancel the run first.',
+        )
+      }
+      if (error.response.status >= 500) {
+        throw new DeleteBenchmarkRunError(
+          'Server error while trying to delete benchmark run.',
+        )
+      }
+      throw new DeleteBenchmarkRunError('Unable to delete benchmark run right now.')
+    }
+
+    throw new DeleteBenchmarkRunError(
+      'Network error while deleting benchmark run. Please try again.',
+    )
+  }
+}
+
 export async function getBenchmarkRunDetails(
   environmentId: string,
   benchmarkId: string,
@@ -383,6 +429,32 @@ export async function getBenchmarkRunRaw(
 
     throw new BenchmarkRunRawError(
       'Network error while loading benchmark run raw data. Please try again.',
+    )
+  }
+}
+
+export async function listBenchmarkRuns(
+  environmentId: string,
+  benchmarkId: string,
+  signal?: AbortSignal,
+): Promise<Array<BenchmarkRunDTO>> {
+  const runsApi = createBenchmarkRunsApi()
+
+  try {
+    return await runsApi.listBenchmarkRuns({ environmentId, benchmarkId }, { signal })
+  } catch (error: unknown) {
+    if (error instanceof ResponseError) {
+      if (error.response.status === 404) {
+        throw new BenchmarkRunsLoadError('Benchmark was not found.')
+      }
+
+      throw new BenchmarkRunsLoadError(
+        readLoadErrorMessage(error, 'benchmark runs'),
+      )
+    }
+
+    throw new BenchmarkRunsLoadError(
+      'Network error while loading benchmark runs. Please try again.',
     )
   }
 }

--- a/src/features/environments/EnvironmentDetailsPage.tsx
+++ b/src/features/environments/EnvironmentDetailsPage.tsx
@@ -444,11 +444,23 @@ export function EnvironmentDetailsPage() {
                             </span>
                           </td>
                           <td>
-                            <div className="benchmark-table-actions">
-                              {canGoToRun ? (
-                                <button
-                                  type="button"
-                                  className="auth-button benchmark-go-to-run-action"
+                             <div className="benchmark-table-actions">
+                               <button
+                                 type="button"
+                                 className="shell-alert-dismiss benchmark-table-action-secondary"
+                                 onClick={() =>
+                                   navigate(
+                                     `/environments/${environmentId}/benchmarks/${benchmarkId}`,
+                                   )
+                                 }
+                                 disabled={!benchmarkId}
+                               >
+                                 Details
+                               </button>
+                               {canGoToRun ? (
+                                 <button
+                                   type="button"
+                                   className="auth-button benchmark-go-to-run-action"
                                   onClick={() =>
                                     navigate(
                                       `/environments/${environmentId}/benchmarks/${benchmarkId}/runs/${activeRunId}`,


### PR DESCRIPTION
Closes #15

## Summary
- add benchmark details page at /environments/:environmentId/benchmarks/:benchmarkId
- show benchmark metadata and benchmark instructions with integrated syntax coloring
- add full-width benchmark run history table with status, start/end/runtime and actions
- add run lifecycle actions per row:
  - Run details navigation
  - Cancel run for active runs
  - Delete run data for non-active runs
- add header actions:
  - Edit (disabled when benchmark has active run)
  - Start run (disabled when any run is active in the environment)
  - Back to environment
- add service wrappers for benchmark runs:
  - listBenchmarkRuns
  - deleteBenchmarkRun
- wire environment benchmark list with Details navigation entry

## Validation
- npm run lint
- npm run build