### PR TITLE
refactor(benchmark): add domain services for benchmark and run ops

### DIFF
--- a/src/features/benchmarks/domain/contracts.ts
+++ b/src/features/benchmarks/domain/contracts.ts
@@ -1,0 +1,15 @@
+import type { BenchmarkDTO } from '../../../generated/openapi/models/BenchmarkDTO'
+
+export type BenchmarkMutationInput = Pick<
+  BenchmarkDTO,
+  'name' | 'description' | 'k6Instructions'
+>
+
+export interface ListEnvironmentRunsPageInput {
+  environmentId: string
+  page: number
+  size: number
+  sort?: string
+  signal?: AbortSignal
+}
+

--- a/src/features/benchmarks/domain/errors.ts
+++ b/src/features/benchmarks/domain/errors.ts
@@ -1,0 +1,145 @@
+export type BenchmarkDomainErrorKind =
+  | 'validation'
+  | 'not_found'
+  | 'conflict'
+  | 'server'
+  | 'network'
+  | 'unknown'
+
+export type BenchmarkDomainOperation =
+  | 'list-benchmarks'
+  | 'create-benchmark'
+  | 'get-benchmark'
+  | 'update-benchmark'
+  | 'start-run'
+  | 'stop-run'
+  | 'delete-run'
+  | 'get-run-details'
+  | 'get-run-raw'
+  | 'list-runs'
+  | 'list-environment-runs'
+  | 'unknown'
+
+export interface BenchmarkDomainErrorMetadata {
+  kind?: BenchmarkDomainErrorKind
+  operation?: BenchmarkDomainOperation
+  statusCode?: number
+  cause?: unknown
+}
+
+export class BenchmarkDomainError extends Error {
+  readonly kind: BenchmarkDomainErrorKind
+  readonly operation: BenchmarkDomainOperation
+  readonly statusCode?: number
+  readonly cause?: unknown
+
+  constructor(
+    name: string,
+    message: string,
+    metadata: BenchmarkDomainErrorMetadata = {},
+  ) {
+    super(message)
+    this.name = name
+    this.kind = metadata.kind ?? 'unknown'
+    this.operation = metadata.operation ?? 'unknown'
+    this.statusCode = metadata.statusCode
+    this.cause = metadata.cause
+  }
+}
+
+export function isBenchmarkDomainError(
+  error: unknown,
+): error is BenchmarkDomainError {
+  return error instanceof BenchmarkDomainError
+}
+
+export class BenchmarksLoadError extends BenchmarkDomainError {
+  constructor(message: string, metadata: BenchmarkDomainErrorMetadata = {}) {
+    super('BenchmarksLoadError', message, {
+      operation: 'list-benchmarks',
+      ...metadata,
+    })
+  }
+}
+
+export class BenchmarkRunsLoadError extends BenchmarkDomainError {
+  constructor(message: string, metadata: BenchmarkDomainErrorMetadata = {}) {
+    super('BenchmarkRunsLoadError', message, {
+      operation: 'list-runs',
+      ...metadata,
+    })
+  }
+}
+
+export class CreateBenchmarkError extends BenchmarkDomainError {
+  constructor(message: string, metadata: BenchmarkDomainErrorMetadata = {}) {
+    super('CreateBenchmarkError', message, {
+      operation: 'create-benchmark',
+      ...metadata,
+    })
+  }
+}
+
+export class GetBenchmarkError extends BenchmarkDomainError {
+  constructor(message: string, metadata: BenchmarkDomainErrorMetadata = {}) {
+    super('GetBenchmarkError', message, {
+      operation: 'get-benchmark',
+      ...metadata,
+    })
+  }
+}
+
+export class UpdateBenchmarkError extends BenchmarkDomainError {
+  constructor(message: string, metadata: BenchmarkDomainErrorMetadata = {}) {
+    super('UpdateBenchmarkError', message, {
+      operation: 'update-benchmark',
+      ...metadata,
+    })
+  }
+}
+
+export class StartBenchmarkError extends BenchmarkDomainError {
+  constructor(message: string, metadata: BenchmarkDomainErrorMetadata = {}) {
+    super('StartBenchmarkError', message, {
+      operation: 'start-run',
+      ...metadata,
+    })
+  }
+}
+
+export class StopBenchmarkRunError extends BenchmarkDomainError {
+  constructor(message: string, metadata: BenchmarkDomainErrorMetadata = {}) {
+    super('StopBenchmarkRunError', message, {
+      operation: 'stop-run',
+      ...metadata,
+    })
+  }
+}
+
+export class DeleteBenchmarkRunError extends BenchmarkDomainError {
+  constructor(message: string, metadata: BenchmarkDomainErrorMetadata = {}) {
+    super('DeleteBenchmarkRunError', message, {
+      operation: 'delete-run',
+      ...metadata,
+    })
+  }
+}
+
+export class BenchmarkRunDetailsError extends BenchmarkDomainError {
+  constructor(message: string, metadata: BenchmarkDomainErrorMetadata = {}) {
+    super('BenchmarkRunDetailsError', message, {
+      operation: 'get-run-details',
+      ...metadata,
+    })
+  }
+}
+
+export class BenchmarkRunRawError extends BenchmarkDomainError {
+  constructor(message: string, metadata: BenchmarkDomainErrorMetadata = {}) {
+    super('BenchmarkRunRawError', message, {
+      operation: 'get-run-raw',
+      ...metadata,
+    })
+  }
+}
+

--- a/src/features/benchmarks/domain/gateways/benchmarkGateway.ts
+++ b/src/features/benchmarks/domain/gateways/benchmarkGateway.ts
@@ -1,0 +1,121 @@
+import type { BenchmarkDTO } from '../../../../generated/openapi/models/BenchmarkDTO'
+import { createBenchmarkApi } from '../../../../auth/client'
+import { ResponseError } from '../../../../generated/openapi/runtime'
+import type { BenchmarkMutationInput } from '../contracts'
+import {
+  BenchmarksLoadError,
+  CreateBenchmarkError,
+  GetBenchmarkError,
+  UpdateBenchmarkError,
+} from '../errors'
+import {
+  readLoadErrorMessage,
+  readMutationErrorMessage,
+  toResponseErrorMetadata,
+} from './messageMapping'
+
+export async function listBenchmarksGateway(
+  environmentId: string,
+): Promise<Array<BenchmarkDTO>> {
+  const benchmarkApi = createBenchmarkApi()
+
+  try {
+    return await benchmarkApi.listBenchmarks({ environmentId })
+  } catch (error: unknown) {
+    if (error instanceof ResponseError) {
+      throw new BenchmarksLoadError(readLoadErrorMessage(error, 'benchmarks'), {
+        ...toResponseErrorMetadata(error),
+      })
+    }
+
+    throw new BenchmarksLoadError(
+      'Network error while loading benchmarks. Please try again.',
+      {
+        kind: 'network',
+        cause: error,
+      },
+    )
+  }
+}
+
+export async function createBenchmarkGateway(
+  environmentId: string,
+  input: BenchmarkMutationInput,
+): Promise<BenchmarkDTO> {
+  const benchmarkApi = createBenchmarkApi()
+
+  try {
+    return await benchmarkApi.createBenchmark({ environmentId, benchmarkDTO: input })
+  } catch (error: unknown) {
+    if (error instanceof ResponseError) {
+      throw new CreateBenchmarkError(readMutationErrorMessage(error, 'create'), {
+        ...toResponseErrorMetadata(error),
+      })
+    }
+
+    throw new CreateBenchmarkError(
+      'Network error while creating benchmark. Please try again.',
+      {
+        kind: 'network',
+        cause: error,
+      },
+    )
+  }
+}
+
+export async function getBenchmarkGateway(
+  environmentId: string,
+  benchmarkId: string,
+  signal?: AbortSignal,
+): Promise<BenchmarkDTO> {
+  const benchmarkApi = createBenchmarkApi()
+
+  try {
+    return await benchmarkApi.getBenchmark({ environmentId, benchmarkId }, { signal })
+  } catch (error: unknown) {
+    if (error instanceof ResponseError) {
+      throw new GetBenchmarkError(readMutationErrorMessage(error, 'get'), {
+        ...toResponseErrorMetadata(error),
+      })
+    }
+
+    throw new GetBenchmarkError(
+      'Network error while loading benchmark details. Please try again.',
+      {
+        kind: 'network',
+        cause: error,
+      },
+    )
+  }
+}
+
+export async function updateBenchmarkGateway(
+  environmentId: string,
+  benchmarkId: string,
+  input: BenchmarkMutationInput,
+): Promise<BenchmarkDTO> {
+  const benchmarkApi = createBenchmarkApi()
+
+  try {
+    return await benchmarkApi.updateBenchmark({
+      environmentId,
+      benchmarkId,
+      benchmarkDTO: input,
+    })
+  } catch (error: unknown) {
+    if (error instanceof ResponseError) {
+      throw new UpdateBenchmarkError(readMutationErrorMessage(error, 'update'), {
+        ...toResponseErrorMetadata(error),
+      })
+    }
+
+    throw new UpdateBenchmarkError(
+      'Network error while updating benchmark. Please try again.',
+      {
+        kind: 'network',
+        cause: error,
+      },
+    )
+  }
+}
+

--- a/src/features/benchmarks/domain/gateways/benchmarkRunGateway.ts
+++ b/src/features/benchmarks/domain/gateways/benchmarkRunGateway.ts
@@ -1,0 +1,274 @@
+import type { BenchmarkRunDerivedDTO } from '../../../../generated/openapi/models/BenchmarkRunDerivedDTO'
+import type { BenchmarkRunDTO } from '../../../../generated/openapi/models/BenchmarkRunDTO'
+import type { BenchmarkRunRawDTO } from '../../../../generated/openapi/models/BenchmarkRunRawDTO'
+import type { BenchmarkStatusDTO } from '../../../../generated/openapi/models/BenchmarkStatusDTO'
+import { createBenchmarkActionsApi, createBenchmarkRunsApi } from '../../../../auth/client'
+import { ResponseError } from '../../../../generated/openapi/runtime'
+import {
+  BenchmarkRunDetailsError,
+  BenchmarkRunRawError,
+  BenchmarkRunsLoadError,
+  DeleteBenchmarkRunError,
+  StartBenchmarkError,
+  StopBenchmarkRunError,
+} from '../errors'
+import { readLoadErrorMessage, toResponseErrorMetadata } from './messageMapping'
+
+export async function startBenchmarkGateway(
+  environmentId: string,
+  benchmarkId: string,
+): Promise<BenchmarkStatusDTO> {
+  const benchmarkActionsApi = createBenchmarkActionsApi()
+
+  try {
+    return await benchmarkActionsApi.startBenchmark({ environmentId, benchmarkId })
+  } catch (error: unknown) {
+    if (error instanceof ResponseError) {
+      if (error.response.status === 400) {
+        throw new StartBenchmarkError(
+          'Benchmark could not be started with the current configuration.',
+          { ...toResponseErrorMetadata(error) },
+        )
+      }
+      if (error.response.status === 404) {
+        throw new StartBenchmarkError('Benchmark was not found.', {
+          ...toResponseErrorMetadata(error),
+        })
+      }
+      if (error.response.status === 409) {
+        throw new StartBenchmarkError(
+          'This benchmark already has an active run in this environment.',
+          { ...toResponseErrorMetadata(error) },
+        )
+      }
+      if (error.response.status >= 500) {
+        throw new StartBenchmarkError(
+          'Server error while trying to start benchmark.',
+          { ...toResponseErrorMetadata(error) },
+        )
+      }
+
+      throw new StartBenchmarkError('Unable to start benchmark right now.', {
+        ...toResponseErrorMetadata(error),
+      })
+    }
+
+    throw new StartBenchmarkError(
+      'Network error while starting benchmark. Please try again.',
+      {
+        kind: 'network',
+        cause: error,
+      },
+    )
+  }
+}
+
+export async function stopBenchmarkRunGateway(
+  environmentId: string,
+  benchmarkId: string,
+  runId: string,
+): Promise<BenchmarkStatusDTO> {
+  const benchmarkActionsApi = createBenchmarkActionsApi()
+
+  try {
+    return await benchmarkActionsApi.stopBenchmarkRun({ environmentId, benchmarkId, runId })
+  } catch (error: unknown) {
+    if (error instanceof ResponseError) {
+      if (error.response.status === 400) {
+        throw new StopBenchmarkRunError(
+          'This run is not in a stoppable state right now.',
+          { ...toResponseErrorMetadata(error) },
+        )
+      }
+      if (error.response.status === 409) {
+        throw new StopBenchmarkRunError(
+          'This run is already stopping and cannot be cancelled again.',
+          { ...toResponseErrorMetadata(error) },
+        )
+      }
+      if (error.response.status === 404) {
+        throw new StopBenchmarkRunError('Benchmark run was not found.', {
+          ...toResponseErrorMetadata(error),
+        })
+      }
+      if (error.response.status >= 500) {
+        throw new StopBenchmarkRunError(
+          'Server error while trying to stop benchmark run.',
+          { ...toResponseErrorMetadata(error) },
+        )
+      }
+      throw new StopBenchmarkRunError('Unable to stop benchmark run right now.', {
+        ...toResponseErrorMetadata(error),
+      })
+    }
+
+    throw new StopBenchmarkRunError(
+      'Network error while stopping benchmark run. Please try again.',
+      {
+        kind: 'network',
+        cause: error,
+      },
+    )
+  }
+}
+
+export async function deleteBenchmarkRunGateway(
+  environmentId: string,
+  benchmarkId: string,
+  runId: string,
+): Promise<void> {
+  const runsApi = createBenchmarkRunsApi()
+
+  try {
+    await runsApi.deleteBenchmarkRun({ environmentId, benchmarkId, runId })
+  } catch (error: unknown) {
+    if (error instanceof ResponseError) {
+      if (error.response.status === 400) {
+        throw new DeleteBenchmarkRunError(
+          'This run cannot be deleted in its current state.',
+          { ...toResponseErrorMetadata(error) },
+        )
+      }
+      if (error.response.status === 404) {
+        throw new DeleteBenchmarkRunError('Benchmark run was not found.', {
+          ...toResponseErrorMetadata(error),
+        })
+      }
+      if (error.response.status === 409) {
+        throw new DeleteBenchmarkRunError(
+          'Active runs cannot be deleted. Cancel the run first.',
+          { ...toResponseErrorMetadata(error) },
+        )
+      }
+      if (error.response.status >= 500) {
+        throw new DeleteBenchmarkRunError(
+          'Server error while trying to delete benchmark run.',
+          { ...toResponseErrorMetadata(error) },
+        )
+      }
+      throw new DeleteBenchmarkRunError('Unable to delete benchmark run right now.', {
+        ...toResponseErrorMetadata(error),
+      })
+    }
+
+    throw new DeleteBenchmarkRunError(
+      'Network error while deleting benchmark run. Please try again.',
+      {
+        kind: 'network',
+        cause: error,
+      },
+    )
+  }
+}
+
+export async function getBenchmarkRunDetailsGateway(
+  environmentId: string,
+  benchmarkId: string,
+  runId: string,
+  signal?: AbortSignal,
+): Promise<BenchmarkRunDerivedDTO> {
+  const runsApi = createBenchmarkRunsApi()
+
+  try {
+    return await runsApi.getBenchmarkRun(
+      { environmentId, benchmarkId, runId },
+      { signal },
+    )
+  } catch (error: unknown) {
+    if (error instanceof ResponseError) {
+      if (error.response.status === 404) {
+        throw new BenchmarkRunDetailsError('Benchmark run was not found.', {
+          ...toResponseErrorMetadata(error),
+        })
+      }
+
+      throw new BenchmarkRunDetailsError(
+        readLoadErrorMessage(error, 'benchmark run details'),
+        { ...toResponseErrorMetadata(error) },
+      )
+    }
+
+    throw new BenchmarkRunDetailsError(
+      'Network error while loading benchmark run details. Please try again.',
+      {
+        kind: 'network',
+        cause: error,
+      },
+    )
+  }
+}
+
+export async function getBenchmarkRunRawGateway(
+  environmentId: string,
+  benchmarkId: string,
+  runId: string,
+  signal?: AbortSignal,
+): Promise<BenchmarkRunRawDTO> {
+  const runsApi = createBenchmarkRunsApi()
+
+  try {
+    const response = await runsApi.getBenchmarkRunDataRaw(
+      {
+        environmentId,
+        benchmarkId,
+        runId,
+      },
+      { signal },
+    )
+    return await response.value()
+  } catch (error: unknown) {
+    if (error instanceof ResponseError) {
+      if (error.response.status === 404) {
+        throw new BenchmarkRunRawError('Benchmark run was not found.', {
+          ...toResponseErrorMetadata(error),
+        })
+      }
+
+      throw new BenchmarkRunRawError(
+        readLoadErrorMessage(error, 'benchmark run raw data'),
+        { ...toResponseErrorMetadata(error) },
+      )
+    }
+
+    throw new BenchmarkRunRawError(
+      'Network error while loading benchmark run raw data. Please try again.',
+      {
+        kind: 'network',
+        cause: error,
+      },
+    )
+  }
+}
+
+export async function listBenchmarkRunsGateway(
+  environmentId: string,
+  benchmarkId: string,
+  signal?: AbortSignal,
+): Promise<Array<BenchmarkRunDTO>> {
+  const runsApi = createBenchmarkRunsApi()
+
+  try {
+    return await runsApi.listBenchmarkRuns({ environmentId, benchmarkId }, { signal })
+  } catch (error: unknown) {
+    if (error instanceof ResponseError) {
+      if (error.response.status === 404) {
+        throw new BenchmarkRunsLoadError('Benchmark was not found.', {
+          ...toResponseErrorMetadata(error),
+        })
+      }
+
+      throw new BenchmarkRunsLoadError(readLoadErrorMessage(error, 'benchmark runs'), {
+        ...toResponseErrorMetadata(error),
+      })
+    }
+
+    throw new BenchmarkRunsLoadError(
+      'Network error while loading benchmark runs. Please try again.',
+      {
+        kind: 'network',
+        cause: error,
+      },
+    )
+  }
+}
+

--- a/src/features/benchmarks/domain/gateways/environmentRunGateway.ts
+++ b/src/features/benchmarks/domain/gateways/environmentRunGateway.ts
@@ -1,0 +1,77 @@
+import type { EnvironmentRunsDTO } from '../../../../generated/openapi/models/EnvironmentRunsDTO'
+import {
+  EnvironmentRunSummaryDTOStatusEnum,
+  type EnvironmentRunSummaryDTO,
+} from '../../../../generated/openapi/models/EnvironmentRunSummaryDTO'
+import { createBenchmarkRunsApi } from '../../../../auth/client'
+import { ResponseError } from '../../../../generated/openapi/runtime'
+import type { ListEnvironmentRunsPageInput } from '../contracts'
+import { BenchmarkRunsLoadError } from '../errors'
+import { readLoadErrorMessage, toResponseErrorMetadata } from './messageMapping'
+
+const ACTIVE_STATUS_SET = new Set([
+  EnvironmentRunSummaryDTOStatusEnum.PendingStart,
+  EnvironmentRunSummaryDTOStatusEnum.Started,
+  EnvironmentRunSummaryDTOStatusEnum.PendingStop,
+])
+
+export async function listEnvironmentRunsPageGateway(
+  input: ListEnvironmentRunsPageInput,
+): Promise<EnvironmentRunsDTO> {
+  const runsApi = createBenchmarkRunsApi()
+  const { environmentId, page, size, sort = 'startedAt,desc', signal } = input
+
+  try {
+    return await runsApi.listEnvironmentRuns(
+      {
+        environmentId,
+        page,
+        size,
+        sort,
+      },
+      { signal },
+    )
+  } catch (error: unknown) {
+    if (error instanceof ResponseError) {
+      throw new BenchmarkRunsLoadError(readLoadErrorMessage(error, 'environment runs'), {
+        operation: 'list-environment-runs',
+        ...toResponseErrorMetadata(error),
+      })
+    }
+
+    throw new BenchmarkRunsLoadError(
+      'Network error while loading environment runs. Please try again.',
+      {
+        kind: 'network',
+        operation: 'list-environment-runs',
+        cause: error,
+      },
+    )
+  }
+}
+
+export async function listActiveEnvironmentRunsGateway(
+  environmentId: string,
+  signal?: AbortSignal,
+): Promise<Array<EnvironmentRunSummaryDTO>> {
+  const response = await listEnvironmentRunsPageGateway({
+    environmentId,
+    page: 0,
+    size: 50,
+    sort: 'startedAt,desc',
+    signal,
+  })
+
+  const runs = response.runs ?? []
+  return runs.filter(
+    (run) =>
+      run.status != null &&
+      ACTIVE_STATUS_SET.has(
+        run.status as
+          | typeof EnvironmentRunSummaryDTOStatusEnum.PendingStart
+          | typeof EnvironmentRunSummaryDTOStatusEnum.Started
+          | typeof EnvironmentRunSummaryDTOStatusEnum.PendingStop,
+      ),
+  )
+}
+

--- a/src/features/benchmarks/domain/gateways/messageMapping.ts
+++ b/src/features/benchmarks/domain/gateways/messageMapping.ts
@@ -1,0 +1,58 @@
+import { ResponseError } from '../../../../generated/openapi/runtime'
+import type { BenchmarkDomainErrorMetadata } from '../errors'
+
+export function toResponseErrorMetadata(
+  error: ResponseError,
+): BenchmarkDomainErrorMetadata {
+  const statusCode = error.response.status
+  if (statusCode === 400) {
+    return { kind: 'validation', statusCode, cause: error }
+  }
+  if (statusCode === 404) {
+    return { kind: 'not_found', statusCode, cause: error }
+  }
+  if (statusCode === 409) {
+    return { kind: 'conflict', statusCode, cause: error }
+  }
+  if (statusCode >= 500) {
+    return { kind: 'server', statusCode, cause: error }
+  }
+
+  return { kind: 'unknown', statusCode, cause: error }
+}
+
+export function readLoadErrorMessage(error: ResponseError, subject: string): string {
+  if (error.response.status === 404) {
+    return `${subject} endpoint was not found.`
+  }
+
+  if (error.response.status >= 500) {
+    return `Server error while loading ${subject}.`
+  }
+
+  return `Unable to load ${subject} right now.`
+}
+
+export function readMutationErrorMessage(
+  error: ResponseError,
+  action: 'create' | 'get' | 'update',
+): string {
+  if ((action === 'create' || action === 'update') && error.response.status === 400) {
+    return 'There was a problem with your benchmark data. Please review the form and try again.'
+  }
+
+  if (error.response.status === 404) {
+    return action === 'get'
+      ? 'Benchmark was not found.'
+      : 'Benchmark target was not found.'
+  }
+
+  const actionLabel =
+    action === 'create' ? 'create' : action === 'update' ? 'update' : 'load'
+  if (error.response.status >= 500) {
+    return `Server error while trying to ${actionLabel} benchmark.`
+  }
+
+  return `Unable to ${actionLabel} benchmark right now.`
+}
+

--- a/src/features/benchmarks/domain/index.ts
+++ b/src/features/benchmarks/domain/index.ts
@@ -1,4 +1,4 @@
-export type { BenchmarkMutationInput } from './domain'
+export type { BenchmarkMutationInput } from './contracts'
 export {
   BenchmarkDomainError,
   BenchmarksLoadError,
@@ -12,17 +12,19 @@ export {
   BenchmarkRunDetailsError,
   BenchmarkRunRawError,
   isBenchmarkDomainError,
-} from './domain'
+} from './errors'
 export type {
   BenchmarkDomainErrorKind,
   BenchmarkDomainOperation,
   BenchmarkDomainErrorMetadata,
-} from './domain'
+} from './errors'
 export {
   listBenchmarks,
   createBenchmark,
   getBenchmark,
   updateBenchmark,
+} from './services/benchmarkService'
+export {
   startBenchmark,
   stopBenchmarkRun,
   deleteBenchmarkRun,
@@ -30,5 +32,5 @@ export {
   getBenchmarkRunRaw,
   listBenchmarkRuns,
   listActiveEnvironmentRuns,
-} from './domain'
+} from './services/runService'
 

--- a/src/features/benchmarks/domain/services/benchmarkService.ts
+++ b/src/features/benchmarks/domain/services/benchmarkService.ts
@@ -1,0 +1,38 @@
+import type { BenchmarkDTO } from '../../../../generated/openapi/models/BenchmarkDTO'
+import type { BenchmarkMutationInput } from '../contracts'
+import {
+  createBenchmarkGateway,
+  getBenchmarkGateway,
+  listBenchmarksGateway,
+  updateBenchmarkGateway,
+} from '../gateways/benchmarkGateway'
+
+export async function listBenchmarks(
+  environmentId: string,
+): Promise<Array<BenchmarkDTO>> {
+  return await listBenchmarksGateway(environmentId)
+}
+
+export async function createBenchmark(
+  environmentId: string,
+  input: BenchmarkMutationInput,
+): Promise<BenchmarkDTO> {
+  return await createBenchmarkGateway(environmentId, input)
+}
+
+export async function getBenchmark(
+  environmentId: string,
+  benchmarkId: string,
+  signal?: AbortSignal,
+): Promise<BenchmarkDTO> {
+  return await getBenchmarkGateway(environmentId, benchmarkId, signal)
+}
+
+export async function updateBenchmark(
+  environmentId: string,
+  benchmarkId: string,
+  input: BenchmarkMutationInput,
+): Promise<BenchmarkDTO> {
+  return await updateBenchmarkGateway(environmentId, benchmarkId, input)
+}
+

--- a/src/features/benchmarks/domain/services/runService.ts
+++ b/src/features/benchmarks/domain/services/runService.ts
@@ -22,29 +22,15 @@ async function findEnvironmentRunSummary(
   runId: string,
 ): Promise<EnvironmentRunSummaryDTO | null> {
   const size = 100
-  let page = 0
+  const maxPages = 20
+  const response = await listEnvironmentRunsPageGateway({
+    environmentId,
+    page: 0,
+    size: size * maxPages,
+    sort: 'startedAt,desc',
+  })
 
-  while (page < 20) {
-    const response = await listEnvironmentRunsPageGateway({
-      environmentId,
-      page,
-      size,
-      sort: 'startedAt,desc',
-    })
-
-    const match = (response.runs ?? []).find((run) => run.runId === runId)
-    if (match) {
-      return match
-    }
-
-    const totalPages = response.pagination?.totalPages ?? 0
-    page += 1
-    if (totalPages === 0 || page >= totalPages) {
-      break
-    }
-  }
-
-  return null
+  return (response.runs ?? []).find((run) => run.runId === runId) ?? null
 }
 
 export async function startBenchmark(

--- a/src/features/benchmarks/domain/services/runService.ts
+++ b/src/features/benchmarks/domain/services/runService.ts
@@ -1,0 +1,154 @@
+import type { BenchmarkRunDerivedDTO } from '../../../../generated/openapi/models/BenchmarkRunDerivedDTO'
+import type { BenchmarkRunDTO } from '../../../../generated/openapi/models/BenchmarkRunDTO'
+import type { BenchmarkRunRawDTO } from '../../../../generated/openapi/models/BenchmarkRunRawDTO'
+import type { BenchmarkStatusDTO } from '../../../../generated/openapi/models/BenchmarkStatusDTO'
+import type { EnvironmentRunSummaryDTO } from '../../../../generated/openapi/models/EnvironmentRunSummaryDTO'
+import { BenchmarkRunDetailsError, BenchmarkRunsLoadError } from '../errors'
+import {
+  deleteBenchmarkRunGateway,
+  getBenchmarkRunDetailsGateway,
+  getBenchmarkRunRawGateway,
+  listBenchmarkRunsGateway,
+  startBenchmarkGateway,
+  stopBenchmarkRunGateway,
+} from '../gateways/benchmarkRunGateway'
+import {
+  listActiveEnvironmentRunsGateway,
+  listEnvironmentRunsPageGateway,
+} from '../gateways/environmentRunGateway'
+
+async function findEnvironmentRunSummary(
+  environmentId: string,
+  runId: string,
+): Promise<EnvironmentRunSummaryDTO | null> {
+  const size = 100
+  let page = 0
+
+  while (page < 20) {
+    const response = await listEnvironmentRunsPageGateway({
+      environmentId,
+      page,
+      size,
+      sort: 'startedAt,desc',
+    })
+
+    const match = (response.runs ?? []).find((run) => run.runId === runId)
+    if (match) {
+      return match
+    }
+
+    const totalPages = response.pagination?.totalPages ?? 0
+    page += 1
+    if (totalPages === 0 || page >= totalPages) {
+      break
+    }
+  }
+
+  return null
+}
+
+export async function startBenchmark(
+  environmentId: string,
+  benchmarkId: string,
+): Promise<BenchmarkStatusDTO> {
+  return await startBenchmarkGateway(environmentId, benchmarkId)
+}
+
+export async function stopBenchmarkRun(
+  environmentId: string,
+  benchmarkId: string,
+  runId: string,
+): Promise<BenchmarkStatusDTO> {
+  return await stopBenchmarkRunGateway(environmentId, benchmarkId, runId)
+}
+
+export async function deleteBenchmarkRun(
+  environmentId: string,
+  benchmarkId: string,
+  runId: string,
+): Promise<void> {
+  await deleteBenchmarkRunGateway(environmentId, benchmarkId, runId)
+}
+
+export async function getBenchmarkRunDetails(
+  environmentId: string,
+  benchmarkId: string,
+  runId: string,
+  signal?: AbortSignal,
+): Promise<BenchmarkRunDerivedDTO> {
+  try {
+    return await getBenchmarkRunDetailsGateway(environmentId, benchmarkId, runId, signal)
+  } catch (error: unknown) {
+    if (error instanceof BenchmarkRunDetailsError && error.statusCode === 404) {
+      throw error
+    }
+
+    try {
+      const summary = await findEnvironmentRunSummary(environmentId, runId)
+      if (summary) {
+        return {
+          run: {
+            id: summary.runId,
+            status: summary.status,
+            startedAt: summary.startedAt,
+            finishedAt: summary.finishedAt,
+          },
+        }
+      }
+    } catch {
+      // Keep original API error handling below if fallback lookup also fails.
+    }
+
+    if (error instanceof BenchmarkRunDetailsError) {
+      throw error
+    }
+
+    throw new BenchmarkRunDetailsError(
+      'Network error while loading benchmark run details. Please try again.',
+      {
+        kind: 'network',
+        cause: error,
+      },
+    )
+  }
+}
+
+export async function getBenchmarkRunRaw(
+  environmentId: string,
+  benchmarkId: string,
+  runId: string,
+  signal?: AbortSignal,
+): Promise<BenchmarkRunRawDTO> {
+  return await getBenchmarkRunRawGateway(environmentId, benchmarkId, runId, signal)
+}
+
+export async function listBenchmarkRuns(
+  environmentId: string,
+  benchmarkId: string,
+  signal?: AbortSignal,
+): Promise<Array<BenchmarkRunDTO>> {
+  return await listBenchmarkRunsGateway(environmentId, benchmarkId, signal)
+}
+
+export async function listActiveEnvironmentRuns(
+  environmentId: string,
+  signal?: AbortSignal,
+): Promise<Array<EnvironmentRunSummaryDTO>> {
+  try {
+    return await listActiveEnvironmentRunsGateway(environmentId, signal)
+  } catch (error: unknown) {
+    if (error instanceof BenchmarkRunsLoadError) {
+      throw error
+    }
+
+    throw new BenchmarkRunsLoadError(
+      'Network error while loading environment runs. Please try again.',
+      {
+        kind: 'network',
+        operation: 'list-environment-runs',
+        cause: error,
+      },
+    )
+  }
+}
+


### PR DESCRIPTION
Extract benchmark/run SDK interactions into domain gateways and services, add typed domain error metadata, and keep service.ts as a compatibility facade for existing feature pages.