### PR TITLE
fix(benchmark): reuse runs API client in fallback lookup

### DIFF
--- a/src/features/benchmarks/domain/gateways/environmentRunGateway.ts
+++ b/src/features/benchmarks/domain/gateways/environmentRunGateway.ts
@@ -9,17 +9,23 @@ import type { ListEnvironmentRunsPageInput } from '../contracts'
 import { BenchmarkRunsLoadError } from '../errors'
 import { readLoadErrorMessage, toResponseErrorMetadata } from './messageMapping'
 
+const DEFAULT_ENVIRONMENT_RUN_SORT = 'startedAt,desc'
+const FALLBACK_RUN_LOOKUP_PAGE_SIZE = 100
+const MAX_RUN_LOOKUP_PAGES = 20
+
 const ACTIVE_STATUS_SET = new Set([
   EnvironmentRunSummaryDTOStatusEnum.PendingStart,
   EnvironmentRunSummaryDTOStatusEnum.Started,
   EnvironmentRunSummaryDTOStatusEnum.PendingStop,
 ])
 
-export async function listEnvironmentRunsPageGateway(
+type BenchmarkRunsApiClient = ReturnType<typeof createBenchmarkRunsApi>
+
+async function listEnvironmentRunsPage(
+  runsApi: BenchmarkRunsApiClient,
   input: ListEnvironmentRunsPageInput,
 ): Promise<EnvironmentRunsDTO> {
-  const runsApi = createBenchmarkRunsApi()
-  const { environmentId, page, size, sort = 'startedAt,desc', signal } = input
+  const { environmentId, page, size, sort = DEFAULT_ENVIRONMENT_RUN_SORT, signal } = input
 
   try {
     return await runsApi.listEnvironmentRuns(
@@ -50,15 +56,55 @@ export async function listEnvironmentRunsPageGateway(
   }
 }
 
+export async function listEnvironmentRunsPageGateway(
+  input: ListEnvironmentRunsPageInput,
+): Promise<EnvironmentRunsDTO> {
+  const runsApi = createBenchmarkRunsApi()
+  return await listEnvironmentRunsPage(runsApi, input)
+}
+
+export async function findEnvironmentRunSummaryGateway(
+  environmentId: string,
+  runId: string,
+  signal?: AbortSignal,
+): Promise<EnvironmentRunSummaryDTO | null> {
+  const runsApi = createBenchmarkRunsApi()
+  let page = 0
+
+  while (page < MAX_RUN_LOOKUP_PAGES) {
+    const response = await listEnvironmentRunsPage(runsApi, {
+      environmentId,
+      page,
+      size: FALLBACK_RUN_LOOKUP_PAGE_SIZE,
+      sort: DEFAULT_ENVIRONMENT_RUN_SORT,
+      signal,
+    })
+
+    const match = (response.runs ?? []).find((run) => run.runId === runId)
+    if (match) {
+      return match
+    }
+
+    const totalPages = response.pagination?.totalPages ?? 0
+    page += 1
+    if (totalPages === 0 || page >= totalPages) {
+      break
+    }
+  }
+
+  return null
+}
+
 export async function listActiveEnvironmentRunsGateway(
   environmentId: string,
   signal?: AbortSignal,
 ): Promise<Array<EnvironmentRunSummaryDTO>> {
-  const response = await listEnvironmentRunsPageGateway({
+  const runsApi = createBenchmarkRunsApi()
+  const response = await listEnvironmentRunsPage(runsApi, {
     environmentId,
     page: 0,
     size: 50,
-    sort: 'startedAt,desc',
+    sort: DEFAULT_ENVIRONMENT_RUN_SORT,
     signal,
   })
 

--- a/src/features/benchmarks/domain/gateways/environmentRunGateway.ts
+++ b/src/features/benchmarks/domain/gateways/environmentRunGateway.ts
@@ -80,14 +80,22 @@ export async function findEnvironmentRunSummaryGateway(
       signal,
     })
 
-    const match = (response.runs ?? []).find((run) => run.runId === runId)
+    const runs = response.runs ?? []
+    const match = runs.find((run) => run.runId === runId)
     if (match) {
       return match
     }
 
-    const totalPages = response.pagination?.totalPages ?? 0
+    const totalPages = response.pagination?.totalPages
     page += 1
-    if (totalPages === 0 || page >= totalPages) {
+    if (totalPages != null) {
+      if (page >= totalPages) {
+        break
+      }
+      continue
+    }
+
+    if (runs.length < FALLBACK_RUN_LOOKUP_PAGE_SIZE) {
       break
     }
   }

--- a/src/features/benchmarks/domain/services/runService.ts
+++ b/src/features/benchmarks/domain/services/runService.ts
@@ -13,25 +13,9 @@ import {
   stopBenchmarkRunGateway,
 } from '../gateways/benchmarkRunGateway'
 import {
+  findEnvironmentRunSummaryGateway,
   listActiveEnvironmentRunsGateway,
-  listEnvironmentRunsPageGateway,
 } from '../gateways/environmentRunGateway'
-
-async function findEnvironmentRunSummary(
-  environmentId: string,
-  runId: string,
-): Promise<EnvironmentRunSummaryDTO | null> {
-  const size = 100
-  const maxPages = 20
-  const response = await listEnvironmentRunsPageGateway({
-    environmentId,
-    page: 0,
-    size: size * maxPages,
-    sort: 'startedAt,desc',
-  })
-
-  return (response.runs ?? []).find((run) => run.runId === runId) ?? null
-}
 
 export async function startBenchmark(
   environmentId: string,
@@ -70,7 +54,11 @@ export async function getBenchmarkRunDetails(
     }
 
     try {
-      const summary = await findEnvironmentRunSummary(environmentId, runId)
+      const summary = await findEnvironmentRunSummaryGateway(
+        environmentId,
+        runId,
+        signal,
+      )
       if (summary) {
         return {
           run: {
@@ -81,8 +69,10 @@ export async function getBenchmarkRunDetails(
           },
         }
       }
-    } catch {
-      // Keep original API error handling below if fallback lookup also fails.
+    } catch (lookupError: unknown) {
+      if (!(lookupError instanceof BenchmarkRunsLoadError)) {
+        throw lookupError
+      }
     }
 
     if (error instanceof BenchmarkRunDetailsError) {


### PR DESCRIPTION
## Summary
- move environment-run fallback pagination into the gateway layer
- reuse a single BenchmarkRunsApi client across lookup pages
- keep fallback error handling strict by only swallowing BenchmarkRunsLoadError

## Issue
Related to #22 (already closed by #56).