### PR TITLE
refactor(ui): route benchmark run details by run status

### DIFF
--- a/src/features/benchmarks/BenchmarkDetailsPage.tsx
+++ b/src/features/benchmarks/BenchmarkDetailsPage.tsx
@@ -122,7 +122,7 @@ function getRunDetailsPath(
   environmentId: string,
   benchmarkId: string,
   runId: string,
-  status?: string,
+  status?: BenchmarkRunDTO['status'],
 ): string {
   const runMonitorPath = `/environments/${environmentId}/benchmarks/${benchmarkId}/runs/${runId}`
   if (status === BenchmarkRunDTOStatusEnum.Finished) {

--- a/src/features/benchmarks/BenchmarkDetailsPage.tsx
+++ b/src/features/benchmarks/BenchmarkDetailsPage.tsx
@@ -118,6 +118,20 @@ function formatEndedWithRuntime(run: BenchmarkRunDTO): string {
   return runtime ? `${endedAtLabel} (${runtime})` : endedAtLabel
 }
 
+function getRunDetailsPath(
+  environmentId: string,
+  benchmarkId: string,
+  runId: string,
+  status?: string,
+): string {
+  const runMonitorPath = `/environments/${environmentId}/benchmarks/${benchmarkId}/runs/${runId}`
+  if (status === BenchmarkRunDTOStatusEnum.Finished) {
+    return `${runMonitorPath}/results`
+  }
+
+  return runMonitorPath
+}
+
 export function BenchmarkDetailsPage() {
   const { environmentId = '', benchmarkId = '' } = useParams<{
     environmentId: string
@@ -571,7 +585,12 @@ export function BenchmarkDetailsPage() {
                               className="shell-alert-dismiss benchmark-run-action"
                               onClick={() =>
                                 navigate(
-                                  `/environments/${environmentId}/benchmarks/${benchmarkId}/runs/${runId}`,
+                                  getRunDetailsPath(
+                                    environmentId,
+                                    benchmarkId,
+                                    runId,
+                                    run.status,
+                                  ),
                                 )
                               }
                               disabled={!runId}


### PR DESCRIPTION
## Summary
- add a status-based route helper for the Run details action on Benchmark Details
- route Finished runs to the Run results summary page
- keep all other run statuses routing to the Run monitor page

## Issue
Closes #62