### PR TITLE
refactor(ui): align run back navigation controls

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1098,6 +1098,8 @@
   display: inline-flex;
   align-items: center;
   gap: 0.55rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .run-monitor-status {
@@ -1203,6 +1205,10 @@
 .run-monitor-stop {
   background: #f59e0b;
   color: #7c2d12;
+}
+
+.run-monitor-back {
+  margin: 0;
 }
 
 .run-monitor-stop:hover,
@@ -1386,9 +1392,9 @@
 .run-results-top-row {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
   gap: 1rem;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.8rem;
 }
 
 .run-results-byline {
@@ -1549,13 +1555,6 @@
   line-height: 1.45;
   overflow: auto;
   max-height: 360px;
-}
-
-.run-results-footer-actions {
-  margin-top: 1rem;
-  display: flex;
-  gap: 0.6rem;
-  flex-wrap: wrap;
 }
 
 @media (max-width: 960px) {

--- a/src/features/benchmarks/BenchmarkDetailsPage.tsx
+++ b/src/features/benchmarks/BenchmarkDetailsPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { Link, useNavigate, useParams } from 'react-router-dom'
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom'
 import { getEnvironmentDetails } from '../environments/service'
 import { AsyncStateView } from '../ui/async-state/AsyncState'
 import {
@@ -137,6 +137,7 @@ export function BenchmarkDetailsPage() {
     environmentId: string
     benchmarkId: string
   }>()
+  const location = useLocation()
   const navigate = useNavigate()
 
   const [environmentName, setEnvironmentName] = useState<string | null>(null)
@@ -591,6 +592,7 @@ export function BenchmarkDetailsPage() {
                                     runId,
                                     run.status,
                                   ),
+                                  { state: { from: location.pathname } },
                                 )
                               }
                               disabled={!runId}

--- a/src/features/benchmarks/BenchmarkRunMonitorPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunMonitorPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Link, useNavigate, useParams } from 'react-router-dom'
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom'
 import { getEnvironmentDetails } from '../environments/service'
 import {
   BenchmarkRunDetailsError,
@@ -129,6 +129,7 @@ export function BenchmarkRunMonitorPage() {
     benchmarkId: string
     runId: string
   }>()
+  const location = useLocation()
   const navigate = useNavigate()
   const [environmentName, setEnvironmentName] = useState<string | null>(null)
   const [benchmarkName, setBenchmarkName] = useState<string | null>(null)
@@ -393,9 +394,9 @@ export function BenchmarkRunMonitorPage() {
   }
 
   const handleBackNavigation = () => {
-    const historyState = window.history.state as { idx?: number } | null
-    if (typeof historyState?.idx === 'number' && historyState.idx > 0) {
-      navigate(-1)
+    const backTarget = (location.state as { from?: string } | null)?.from
+    if (typeof backTarget === 'string' && backTarget.startsWith('/')) {
+      navigate(backTarget)
       return
     }
 
@@ -626,6 +627,7 @@ export function BenchmarkRunMonitorPage() {
         <Link
           className="shell-alert-dismiss"
           to={`/environments/${environmentId}/benchmarks/${benchmarkId}/runs/${runId}/results`}
+          state={{ from: location.pathname }}
         >
           View results summary
         </Link>

--- a/src/features/benchmarks/BenchmarkRunMonitorPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunMonitorPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { Link, useNavigate, useParams } from 'react-router-dom'
 import { getEnvironmentDetails } from '../environments/service'
 import {
   BenchmarkRunDetailsError,
@@ -129,6 +129,7 @@ export function BenchmarkRunMonitorPage() {
     benchmarkId: string
     runId: string
   }>()
+  const navigate = useNavigate()
   const [environmentName, setEnvironmentName] = useState<string | null>(null)
   const [benchmarkName, setBenchmarkName] = useState<string | null>(null)
   const [runData, setRunData] = useState<BenchmarkRunDTO | null>(null)
@@ -391,6 +392,16 @@ export function BenchmarkRunMonitorPage() {
     void loadRunDetails('initial')
   }
 
+  const handleBackNavigation = () => {
+    const historyState = window.history.state as { idx?: number } | null
+    if (typeof historyState?.idx === 'number' && historyState.idx > 0) {
+      navigate(-1)
+      return
+    }
+
+    navigate('/environments')
+  }
+
   const isLoading = isLoadingNames || isRunLoading
   const endedWithRuntime = runData?.finishedAt
     ? `${formatTimestamp(runData.finishedAt)}${
@@ -415,6 +426,13 @@ export function BenchmarkRunMonitorPage() {
         </div>
         <div className="run-monitor-header-controls">
           <div className="run-monitor-header-actions">
+            <button
+              type="button"
+              className="shell-alert-dismiss run-monitor-back"
+              onClick={handleBackNavigation}
+            >
+              Back
+            </button>
             {isStoppableStatus(runStatus) ? (
               <button
                 type="button"
@@ -604,10 +622,6 @@ export function BenchmarkRunMonitorPage() {
           </p>
         ) : null}
       </AsyncStateView>
-
-      <Link className="shell-alert-dismiss" to={`/environments/${environmentId}`}>
-        Back to environment
-      </Link>
       {canViewResults ? (
         <Link
           className="shell-alert-dismiss"

--- a/src/features/benchmarks/BenchmarkRunResultsPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunResultsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import type { BenchmarkRunDerivedDTO } from '../../generated/openapi/models/BenchmarkRunDerivedDTO'
 import type { BenchmarkRunRawDTO } from '../../generated/openapi/models/BenchmarkRunRawDTO'
 import { getEnvironmentDetails } from '../environments/service'
@@ -76,6 +76,7 @@ export function BenchmarkRunResultsPage() {
     benchmarkId: string
     runId: string
   }>()
+  const location = useLocation()
   const navigate = useNavigate()
 
   const [environmentName, setEnvironmentName] = useState<string | null>(null)
@@ -198,13 +199,17 @@ export function BenchmarkRunResultsPage() {
   )
 
   const handleBackNavigation = () => {
-    const historyState = window.history.state as { idx?: number } | null
-    if (typeof historyState?.idx === 'number' && historyState.idx > 0) {
-      navigate(-1)
+    const backTarget = (location.state as { from?: string } | null)?.from
+    if (typeof backTarget === 'string' && backTarget.startsWith('/')) {
+      navigate(backTarget)
       return
     }
 
-    navigate(`/environments/${environmentId}/benchmarks/${benchmarkId}`)
+    const fallbackPath =
+      environmentId.trim() && benchmarkId.trim()
+        ? `/environments/${environmentId}/benchmarks/${benchmarkId}`
+        : '/environments'
+    navigate(fallbackPath)
   }
 
   return (

--- a/src/features/benchmarks/BenchmarkRunResultsPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunResultsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import type { BenchmarkRunDerivedDTO } from '../../generated/openapi/models/BenchmarkRunDerivedDTO'
 import type { BenchmarkRunRawDTO } from '../../generated/openapi/models/BenchmarkRunRawDTO'
 import { getEnvironmentDetails } from '../environments/service'
@@ -76,6 +76,7 @@ export function BenchmarkRunResultsPage() {
     benchmarkId: string
     runId: string
   }>()
+  const navigate = useNavigate()
 
   const [environmentName, setEnvironmentName] = useState<string | null>(null)
   const [benchmarkName, setBenchmarkName] = useState<string | null>(null)
@@ -196,6 +197,16 @@ export function BenchmarkRunResultsPage() {
     [rawData],
   )
 
+  const handleBackNavigation = () => {
+    const historyState = window.history.state as { idx?: number } | null
+    if (typeof historyState?.idx === 'number' && historyState.idx > 0) {
+      navigate(-1)
+      return
+    }
+
+    navigate(`/environments/${environmentId}/benchmarks/${benchmarkId}`)
+  }
+
   return (
     <article className="shell-page">
       <div className="run-results-top-row">
@@ -205,6 +216,13 @@ export function BenchmarkRunResultsPage() {
             Derived metrics are shown first, with expandable raw payload details below.
           </p>
         </div>
+        <button
+          type="button"
+          className="shell-alert-dismiss"
+          onClick={handleBackNavigation}
+        >
+          Back
+        </button>
       </div>
 
       <AsyncStateView
@@ -420,18 +438,6 @@ export function BenchmarkRunResultsPage() {
           )}
         </section>
       </AsyncStateView>
-
-      <div className="run-results-footer-actions">
-        <Link
-          className="shell-alert-dismiss"
-          to={`/environments/${environmentId}/benchmarks/${benchmarkId}/runs/${runId}`}
-        >
-          Back to run monitor
-        </Link>
-        <Link className="shell-alert-dismiss" to={`/environments/${environmentId}`}>
-          Back to environment
-        </Link>
-      </div>
     </article>
   )
 }

--- a/src/features/environments/EnvironmentDetailsPage.tsx
+++ b/src/features/environments/EnvironmentDetailsPage.tsx
@@ -302,7 +302,10 @@ export function EnvironmentDetailsPage() {
           },
         }))
 
-        navigate(`/environments/${environmentId}/benchmarks/${benchmarkId}/runs/${runId}`)
+        navigate(
+          `/environments/${environmentId}/benchmarks/${benchmarkId}/runs/${runId}`,
+          { state: { from: location.pathname } },
+        )
       } catch (nextError: unknown) {
         if (nextError instanceof StartBenchmarkError) {
           setBenchmarkActionError(nextError.message)
@@ -313,7 +316,7 @@ export function EnvironmentDetailsPage() {
         setStartInFlightByBenchmarkId((current) => ({ ...current, [benchmarkId]: false }))
       }
     },
-    [environmentId, navigate],
+    [environmentId, location.pathname, navigate],
   )
 
   if (notFound) {
@@ -462,11 +465,12 @@ export function EnvironmentDetailsPage() {
                                    type="button"
                                    className="auth-button benchmark-go-to-run-action"
                                   onClick={() =>
-                                    navigate(
+                                   navigate(
                                       `/environments/${environmentId}/benchmarks/${benchmarkId}/runs/${activeRunId}`,
+                                      { state: { from: location.pathname } },
                                     )
-                                  }
-                                >
+                                   }
+                                 >
                                   Go to active run
                                 </button>
                               ) : (


### PR DESCRIPTION
## Summary
- move Run Monitor back action into the top-right header area
- update Run Monitor back behavior to navigate to the previous page, with fallback to `/environments` when no in-app history exists
- update Run Results to use the same top-right Back pattern and history-based navigation, with fallback to benchmark details

## Issue
Closes #59