### PR TITLE
refactor(ui): standardize readable timestamp formatting

### DIFF
--- a/src/features/benchmarks/format.ts
+++ b/src/features/benchmarks/format.ts
@@ -1,24 +1,7 @@
-const TIMESTAMP_FORMATTER = new Intl.DateTimeFormat('en-GB', {
-  day: 'numeric',
-  month: 'short',
-  year: 'numeric',
-  hour: '2-digit',
-  minute: '2-digit',
-  second: '2-digit',
-  hour12: false,
-})
+import { formatReadableTimestamp } from '../dateTime'
 
 export function formatTimestamp(value?: Date | string): string {
-  if (!value) {
-    return 'n/a'
-  }
-
-  const parsed = new Date(value)
-  if (Number.isNaN(parsed.getTime())) {
-    return 'n/a'
-  }
-
-  return TIMESTAMP_FORMATTER.format(parsed)
+  return formatReadableTimestamp(value) ?? 'n/a'
 }
 
 export function formatRunStatus(status?: string): string {

--- a/src/features/benchmarks/format.ts
+++ b/src/features/benchmarks/format.ts
@@ -1,3 +1,13 @@
+const TIMESTAMP_FORMATTER = new Intl.DateTimeFormat('en-GB', {
+  day: 'numeric',
+  month: 'short',
+  year: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  hour12: false,
+})
+
 export function formatTimestamp(value?: Date | string): string {
   if (!value) {
     return 'n/a'
@@ -8,7 +18,7 @@ export function formatTimestamp(value?: Date | string): string {
     return 'n/a'
   }
 
-  return parsed.toLocaleString()
+  return TIMESTAMP_FORMATTER.format(parsed)
 }
 
 export function formatRunStatus(status?: string): string {

--- a/src/features/dateTime.ts
+++ b/src/features/dateTime.ts
@@ -1,0 +1,22 @@
+const TIMESTAMP_FORMATTER = new Intl.DateTimeFormat('en-GB', {
+  day: 'numeric',
+  month: 'short',
+  year: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  hour12: false,
+})
+
+export function formatReadableTimestamp(value?: Date | string): string | null {
+  if (!value) {
+    return null
+  }
+
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) {
+    return null
+  }
+
+  return TIMESTAMP_FORMATTER.format(parsed)
+}

--- a/src/features/environments/format.ts
+++ b/src/features/environments/format.ts
@@ -1,22 +1,5 @@
-const TIMESTAMP_FORMATTER = new Intl.DateTimeFormat('en-GB', {
-  day: 'numeric',
-  month: 'short',
-  year: 'numeric',
-  hour: '2-digit',
-  minute: '2-digit',
-  second: '2-digit',
-  hour12: false,
-})
+import { formatReadableTimestamp } from '../dateTime'
 
 export function formatTimestamp(value?: Date | string): string {
-  if (!value) {
-    return 'Never'
-  }
-
-  const parsed = new Date(value)
-  if (Number.isNaN(parsed.getTime())) {
-    return 'Never'
-  }
-
-  return TIMESTAMP_FORMATTER.format(parsed)
+  return formatReadableTimestamp(value) ?? 'Never'
 }

--- a/src/features/environments/format.ts
+++ b/src/features/environments/format.ts
@@ -1,7 +1,22 @@
-export function formatTimestamp(value?: Date): string {
+const TIMESTAMP_FORMATTER = new Intl.DateTimeFormat('en-GB', {
+  day: 'numeric',
+  month: 'short',
+  year: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  hour12: false,
+})
+
+export function formatTimestamp(value?: Date | string): string {
   if (!value) {
     return 'Never'
   }
 
-  return new Date(value).toLocaleString()
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) {
+    return 'Never'
+  }
+
+  return TIMESTAMP_FORMATTER.format(parsed)
 }


### PR DESCRIPTION
## Summary
- standardize user-facing timestamps to a readable format: `8 Apr 2026, 08:29:01`
- update shared benchmark and environment timestamp formatting helpers
- preserve existing fallback text for missing/invalid values (`n/a` and `Never`)

## Issue
Closes #57