### PR TITLE
feat(ui): interactive charts for benchmark run results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
-        "react-router-dom": "^7.13.1"
+        "react-router-dom": "^7.13.1",
+        "recharts": "^3.8.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
@@ -1491,6 +1492,42 @@
         "node": ">=12"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -2024,6 +2061,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.1.tgz",
@@ -2384,6 +2433,69 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2436,7 +2548,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2451,6 +2563,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@types/wrap-ansi": {
       "version": "3.0.0",
@@ -3473,6 +3591,15 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3836,8 +3963,129 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
@@ -3866,6 +4114,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -4244,6 +4498,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.27.4",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
@@ -4531,6 +4795,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/execa": {
       "version": "9.6.1",
@@ -5297,6 +5567,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -5388,6 +5668,15 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/into-stream": {
       "version": "7.0.0",
@@ -9739,6 +10028,36 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
+      "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
@@ -9867,6 +10186,51 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
@@ -9896,6 +10260,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -10759,6 +11129,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -11120,6 +11496,15 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -11136,6 +11521,28 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -14,28 +14,29 @@
   "dependencies": {
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "react-router-dom": "^7.13.1"
+    "react-router-dom": "^7.13.1",
+    "recharts": "^3.8.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",
     "@openapitools/openapi-generator-cli": "^2.30.2",
+    "@semantic-release/commit-analyzer": "^13.0.0",
+    "@semantic-release/github": "^11.0.0",
+    "@semantic-release/release-notes-generator": "^14.0.0",
     "@tailwindcss/vite": "^4.2.1",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.0.3",
+    "conventional-changelog-conventionalcommits": "^8.0.0",
     "eslint": "^9.36.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.4.0",
+    "semantic-release": "^24.0.0",
     "tailwindcss": "^4.2.1",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.44.0",
     "vite": "^7.1.7",
-    "vitest": "^3.0.0",
-    "@semantic-release/commit-analyzer": "^13.0.0",
-    "@semantic-release/github": "^11.0.0",
-    "@semantic-release/release-notes-generator": "^14.0.0",
-    "conventional-changelog-conventionalcommits": "^8.0.0",
-    "semantic-release": "^24.0.0"
+    "vitest": "^3.0.0"
   }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -1531,6 +1531,98 @@
   color: #3d4b5c;
 }
 
+.run-results-chart-shell {
+  border: 1px solid #d6e2f1;
+  border-radius: 10px;
+  background: #f8fbff;
+  padding: 0.7rem 0.75rem;
+}
+
+.run-results-chart-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.7rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.65rem;
+}
+
+.run-results-axis-mode-group {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+}
+
+.run-results-axis-mode-button {
+  margin-top: 0;
+  min-height: 34px;
+  padding: 0.45rem 0.7rem;
+  font-size: 0.9rem;
+}
+
+.run-results-axis-mode-button.is-selected {
+  --btn-fg: var(--btn-primary-fg);
+  --btn-bg: var(--btn-primary-bg);
+  --btn-bg-hover: var(--btn-primary-hover);
+  --btn-bg-active: var(--btn-primary-active);
+}
+
+.run-results-smoothing-slider-group {
+  min-width: 210px;
+  display: grid;
+  gap: 0.2rem;
+}
+
+.run-results-smoothing-slider-label {
+  margin: 0;
+  font-size: 0.84rem;
+  color: #1f3347;
+}
+
+.run-results-smoothing-slider-input {
+  width: 100%;
+  margin: 0;
+}
+
+.run-results-smoothing-slider-marks {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.4rem;
+  font-size: 0.74rem;
+  color: #5f748a;
+}
+
+.run-results-smoothing-slider-marks span {
+  text-align: center;
+}
+
+.run-results-smoothing-slider-marks span:first-child {
+  justify-self: start;
+}
+
+.run-results-smoothing-slider-marks span:nth-child(2) {
+  justify-self: center;
+}
+
+.run-results-smoothing-slider-marks span:last-child {
+  justify-self: end;
+}
+
+.run-results-chart-reset {
+  margin-top: 0;
+  min-height: 34px;
+  padding: 0.45rem 0.7rem;
+}
+
+.run-results-chart-container {
+  height: 360px;
+  border: 1px solid #d9e2ef;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 0.45rem 0.35rem 0.1rem;
+}
+
 .run-results-table-wrap {
   overflow-x: auto;
   border: 1px solid #d9e2ef;
@@ -1633,6 +1725,10 @@
 @media (max-width: 960px) {
   .run-results-cards {
     grid-template-columns: 1fr;
+  }
+
+  .run-results-chart-container {
+    height: 320px;
   }
 }
 

--- a/src/features/benchmarks/BenchmarkRunResultsPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunResultsPage.tsx
@@ -366,13 +366,26 @@ export function BenchmarkRunResultsPage() {
     () => applyK6SlidingAverage(baseK6ChartPoints, smoothingWindowSize),
     [baseK6ChartPoints, smoothingWindowSize],
   )
+  const maxBrushIndex = Math.max(k6ChartPoints.length - 1, 0)
+  const brushStartIndex = Math.min(Math.max(brushRange?.startIndex ?? 0, 0), maxBrushIndex)
+  const brushEndIndex = Math.min(
+    Math.max(brushRange?.endIndex ?? maxBrushIndex, brushStartIndex),
+    maxBrushIndex,
+  )
+  const visibleK6ChartPoints = useMemo(() => {
+    if (k6ChartPoints.length === 0) {
+      return []
+    }
+
+    return k6ChartPoints.slice(brushStartIndex, brushEndIndex + 1)
+  }, [brushEndIndex, brushStartIndex, k6ChartPoints])
   const msAxisDomain = useMemo(
-    () => resolveYAxisDomain(k6ChartPoints, K6_MS_METRICS, axisScaleMode),
-    [axisScaleMode, k6ChartPoints],
+    () => resolveYAxisDomain(visibleK6ChartPoints, K6_MS_METRICS, axisScaleMode),
+    [axisScaleMode, visibleK6ChartPoints],
   )
   const vusAxisDomain = useMemo(
-    () => resolveYAxisDomain(k6ChartPoints, K6_VUS_METRICS, axisScaleMode),
-    [axisScaleMode, k6ChartPoints],
+    () => resolveYAxisDomain(visibleK6ChartPoints, K6_VUS_METRICS, axisScaleMode),
+    [axisScaleMode, visibleK6ChartPoints],
   )
 
   useEffect(() => {
@@ -385,10 +398,8 @@ export function BenchmarkRunResultsPage() {
       startIndex: 0,
       endIndex: k6ChartPoints.length - 1,
     })
-  }, [k6ChartPoints.length])
+  }, [baseK6ChartPoints, k6ChartPoints.length, runId])
 
-  const brushStartIndex = brushRange?.startIndex ?? 0
-  const brushEndIndex = brushRange?.endIndex ?? Math.max(k6ChartPoints.length - 1, 0)
   const showPointsOnly = chartRenderMode === 'points'
   const isZoomed =
     k6ChartPoints.length > 1 &&
@@ -671,7 +682,7 @@ export function BenchmarkRunResultsPage() {
               </div>
 
               <div className="run-results-chart-container">
-                <ResponsiveContainer width="100%" height={360}>
+                <ResponsiveContainer width="100%" height="100%">
                   <LineChart
                     data={k6ChartPoints}
                     margin={{ top: 12, right: 8, left: 0, bottom: 4 }}

--- a/src/features/benchmarks/BenchmarkRunResultsPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunResultsPage.tsx
@@ -1,9 +1,30 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
+import {
+  Brush,
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
 import type { BenchmarkRunDerivedDTO } from '../../generated/openapi/models/BenchmarkRunDerivedDTO'
 import type { BenchmarkRunRawDTO } from '../../generated/openapi/models/BenchmarkRunRawDTO'
+import { formatReadableTimestamp } from '../dateTime'
 import { getEnvironmentDetails } from '../environments/service'
 import { AsyncStateView } from '../ui/async-state/AsyncState'
+import {
+  applyK6SlidingAverage,
+  K6_MS_METRICS,
+  K6_VUS_METRICS,
+  type AxisScaleMode,
+  type K6MetricKey,
+  normalizeK6ChartPoints,
+  resolveYAxisDomain,
+} from './charting'
 import {
   BenchmarkRunDetailsError,
   BenchmarkRunRawError,
@@ -70,6 +91,143 @@ function getRawErrorMessage(error: unknown): string {
   return 'Unable to load raw run data right now.'
 }
 
+const AXIS_MODE_OPTIONS: Array<{
+  value: AxisScaleMode
+  label: string
+  description: string
+}> = [
+  {
+    value: 'auto',
+    label: 'Auto',
+    description: 'Automatic Y-axis scaling.',
+  },
+  {
+    value: 'from-zero',
+    label: 'From-zero',
+    description: 'Y-axis starts at zero.',
+  },
+  {
+    value: 'tight',
+    label: 'Tight',
+    description: 'Y-axis fits closely around visible data.',
+  },
+]
+
+type ChartRenderMode = 'line' | 'points'
+
+const CHART_RENDER_MODE_OPTIONS: Array<{
+  value: ChartRenderMode
+  label: string
+  description: string
+}> = [
+  {
+    value: 'line',
+    label: 'Line',
+    description: 'Connected line chart.',
+  },
+  {
+    value: 'points',
+    label: 'Points',
+    description: 'Points-only chart rendering.',
+  },
+]
+
+type SeriesVisibility = Record<K6MetricKey, boolean>
+
+const DEFAULT_SERIES_VISIBILITY: SeriesVisibility = {
+  httpResponseTimeMs: true,
+  httpWaitingMs: true,
+  vus: true,
+}
+
+type BrushRange = {
+  startIndex: number
+  endIndex: number
+}
+
+type BrushChangeEvent = {
+  startIndex?: number
+  endIndex?: number
+}
+
+function toTimestampValue(value: number | string): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+
+  if (typeof value === 'string') {
+    const parsedNumber = Number(value)
+    if (Number.isFinite(parsedNumber)) {
+      return parsedNumber
+    }
+
+    const parsedDate = new Date(value)
+    if (!Number.isNaN(parsedDate.getTime())) {
+      return parsedDate.getTime()
+    }
+  }
+
+  return null
+}
+
+function formatChartTickLabel(value: number | string): string {
+  const timestampMs = toTimestampValue(value)
+  if (timestampMs == null) {
+    return ''
+  }
+
+  const formatted = formatReadableTimestamp(new Date(timestampMs))
+  if (!formatted) {
+    return ''
+  }
+
+  return formatted.split(', ')[1] ?? formatted
+}
+
+function formatChartTooltipLabel(label: unknown): string {
+  if (typeof label !== 'number' && typeof label !== 'string') {
+    return 'n/a'
+  }
+
+  const timestampMs = toTimestampValue(label)
+  if (timestampMs == null) {
+    return String(label)
+  }
+
+  return formatReadableTimestamp(new Date(timestampMs)) ?? String(label)
+}
+
+function formatChartTooltipValue(
+  value: number | string | ReadonlyArray<number | string> | null | undefined,
+  name: number | string | undefined,
+): [string, string] {
+  const label = typeof name === 'undefined' ? 'Value' : String(name)
+  const normalizedValue = Array.isArray(value) ? value[0] : value
+
+  if (typeof normalizedValue !== 'number' || Number.isNaN(normalizedValue)) {
+    return ['n/a', label]
+  }
+
+  if (label === 'Virtual users') {
+    return [normalizedValue.toFixed(0), label]
+  }
+
+  return [`${normalizedValue.toFixed(2)} ms`, label]
+}
+
+function toK6MetricKey(value: unknown): K6MetricKey | null {
+  if (value === 'httpResponseTimeMs') {
+    return 'httpResponseTimeMs'
+  }
+  if (value === 'httpWaitingMs') {
+    return 'httpWaitingMs'
+  }
+  if (value === 'vus') {
+    return 'vus'
+  }
+  return null
+}
+
 export function BenchmarkRunResultsPage() {
   const { environmentId = '', benchmarkId = '', runId = '' } = useParams<{
     environmentId: string
@@ -88,6 +246,11 @@ export function BenchmarkRunResultsPage() {
   const [fatalError, setFatalError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [retryAttempt, setRetryAttempt] = useState(0)
+  const [axisScaleMode, setAxisScaleMode] = useState<AxisScaleMode>('auto')
+  const [chartRenderMode, setChartRenderMode] = useState<ChartRenderMode>('line')
+  const [smoothingLevel, setSmoothingLevel] = useState(0)
+  const [visibleSeries, setVisibleSeries] = useState<SeriesVisibility>(DEFAULT_SERIES_VISIBILITY)
+  const [brushRange, setBrushRange] = useState<BrushRange | null>(null)
 
   const environmentLabel = (environmentName ?? environmentId).trim() || 'n/a'
   const benchmarkLabel = (benchmarkName ?? benchmarkId).trim() || 'n/a'
@@ -197,6 +360,86 @@ export function BenchmarkRunResultsPage() {
     () => (rawData ? JSON.stringify(rawData, null, 2) : ''),
     [rawData],
   )
+  const baseK6ChartPoints = useMemo(() => normalizeK6ChartPoints(rawData), [rawData])
+  const smoothingWindowSize = smoothingLevel === 0 ? 1 : smoothingLevel + 1
+  const k6ChartPoints = useMemo(
+    () => applyK6SlidingAverage(baseK6ChartPoints, smoothingWindowSize),
+    [baseK6ChartPoints, smoothingWindowSize],
+  )
+  const msAxisDomain = useMemo(
+    () => resolveYAxisDomain(k6ChartPoints, K6_MS_METRICS, axisScaleMode),
+    [axisScaleMode, k6ChartPoints],
+  )
+  const vusAxisDomain = useMemo(
+    () => resolveYAxisDomain(k6ChartPoints, K6_VUS_METRICS, axisScaleMode),
+    [axisScaleMode, k6ChartPoints],
+  )
+
+  useEffect(() => {
+    if (k6ChartPoints.length === 0) {
+      setBrushRange(null)
+      return
+    }
+
+    setBrushRange({
+      startIndex: 0,
+      endIndex: k6ChartPoints.length - 1,
+    })
+  }, [k6ChartPoints.length])
+
+  const brushStartIndex = brushRange?.startIndex ?? 0
+  const brushEndIndex = brushRange?.endIndex ?? Math.max(k6ChartPoints.length - 1, 0)
+  const showPointsOnly = chartRenderMode === 'points'
+  const isZoomed =
+    k6ChartPoints.length > 1 &&
+    (brushStartIndex > 0 || brushEndIndex < k6ChartPoints.length - 1)
+
+  const handleBrushChange = (nextRange: BrushChangeEvent) => {
+    if (k6ChartPoints.length === 0) {
+      return
+    }
+
+    if (
+      typeof nextRange.startIndex !== 'number' ||
+      typeof nextRange.endIndex !== 'number'
+    ) {
+      return
+    }
+
+    const maxIndex = k6ChartPoints.length - 1
+    const startIndex = Math.min(Math.max(nextRange.startIndex, 0), maxIndex)
+    const endIndex = Math.min(Math.max(nextRange.endIndex, startIndex), maxIndex)
+
+    setBrushRange({ startIndex, endIndex })
+  }
+
+  const handleResetZoom = () => {
+    if (k6ChartPoints.length === 0) {
+      setBrushRange(null)
+      return
+    }
+
+    setBrushRange({
+      startIndex: 0,
+      endIndex: k6ChartPoints.length - 1,
+    })
+  }
+
+  const handleLegendClick = (entry: unknown) => {
+    if (!entry || typeof entry !== 'object' || !('dataKey' in entry)) {
+      return
+    }
+
+    const dataKey = toK6MetricKey((entry as { dataKey?: unknown }).dataKey)
+    if (!dataKey) {
+      return
+    }
+
+    setVisibleSeries((current) => ({
+      ...current,
+      [dataKey]: !current[dataKey],
+    }))
+  }
 
   const handleBackNavigation = () => {
     const backTarget = (location.state as { from?: string } | null)?.from
@@ -338,6 +581,192 @@ export function BenchmarkRunResultsPage() {
               )}
             </article>
           </div>
+        </section>
+
+        <section className="run-results-section">
+          <h2>Interactive chart analysis</h2>
+          {k6ChartPoints.length === 0 ? (
+            <p className="run-results-placeholder">
+              K6 time-series data is not available for this run.
+            </p>
+          ) : (
+            <div className="run-results-chart-shell">
+              <div className="run-results-chart-controls">
+                <div className="run-results-axis-mode-group" role="group" aria-label="Y-axis scale">
+                  {AXIS_MODE_OPTIONS.map((option) => {
+                    const isSelected = axisScaleMode === option.value
+                    return (
+                      <button
+                        key={option.value}
+                        type="button"
+                        className={`shell-alert-dismiss run-results-axis-mode-button${
+                          isSelected ? ' is-selected' : ''
+                        }`}
+                        onClick={() => setAxisScaleMode(option.value)}
+                        aria-pressed={isSelected}
+                        title={option.description}
+                      >
+                        {option.label}
+                      </button>
+                    )
+                  })}
+                </div>
+                <div className="run-results-axis-mode-group" role="group" aria-label="Chart render mode">
+                  {CHART_RENDER_MODE_OPTIONS.map((option) => {
+                    const isSelected = chartRenderMode === option.value
+                    return (
+                      <button
+                        key={option.value}
+                        type="button"
+                        className={`shell-alert-dismiss run-results-axis-mode-button${
+                          isSelected ? ' is-selected' : ''
+                        }`}
+                        onClick={() => setChartRenderMode(option.value)}
+                        aria-pressed={isSelected}
+                        title={option.description}
+                      >
+                        {option.label}
+                      </button>
+                    )
+                  })}
+                </div>
+                <div className="run-results-smoothing-slider-group">
+                  <label
+                    className="run-results-smoothing-slider-label"
+                    htmlFor="run-results-smoothing-slider"
+                  >
+                    Sliding average: {smoothingLevel === 0 ? 'Raw' : smoothingLevel}
+                  </label>
+                  <input
+                    id="run-results-smoothing-slider"
+                    className="run-results-smoothing-slider-input"
+                    type="range"
+                    min={0}
+                    max={9}
+                    step={1}
+                    value={smoothingLevel}
+                    onChange={(event) => {
+                      const nextLevel = Number(event.currentTarget.value)
+                      if (Number.isNaN(nextLevel)) {
+                        return
+                      }
+                      setSmoothingLevel(Math.min(Math.max(nextLevel, 0), 9))
+                    }}
+                    aria-label="Sliding average level from 0 to 9"
+                  />
+                  <div className="run-results-smoothing-slider-marks" aria-hidden="true">
+                    <span>Raw</span>
+                    <span>5</span>
+                    <span>9</span>
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  className="shell-alert-dismiss run-results-chart-reset"
+                  onClick={handleResetZoom}
+                  disabled={!isZoomed}
+                >
+                  Reset zoom
+                </button>
+              </div>
+
+              <div className="run-results-chart-container">
+                <ResponsiveContainer width="100%" height={360}>
+                  <LineChart
+                    data={k6ChartPoints}
+                    margin={{ top: 12, right: 8, left: 0, bottom: 4 }}
+                  >
+                    <CartesianGrid stroke="#d9e2ef" strokeDasharray="3 3" />
+                    <XAxis
+                      dataKey="timestampMs"
+                      type="number"
+                      domain={['dataMin', 'dataMax']}
+                      minTickGap={42}
+                      tickFormatter={formatChartTickLabel}
+                    />
+                    <YAxis
+                      yAxisId="ms"
+                      domain={msAxisDomain}
+                      tickFormatter={(value: number) => `${Math.round(value)} ms`}
+                      width={68}
+                    />
+                    <YAxis
+                      yAxisId="vus"
+                      orientation="right"
+                      domain={vusAxisDomain}
+                      tickFormatter={(value: number) => `${Math.round(value)}`}
+                      width={46}
+                    />
+                    <Tooltip
+                      formatter={formatChartTooltipValue}
+                      labelFormatter={formatChartTooltipLabel}
+                      isAnimationActive={false}
+                    />
+                    <Legend onClick={handleLegendClick} />
+                    <Line
+                      yAxisId="ms"
+                      type="linear"
+                      dataKey="httpResponseTimeMs"
+                      name="HTTP response time"
+                      hide={!visibleSeries.httpResponseTimeMs}
+                      stroke="#2563eb"
+                      strokeWidth={showPointsOnly ? 0.0001 : 2}
+                      dot={
+                        showPointsOnly
+                          ? { r: 3.5, fill: '#2563eb', stroke: '#2563eb', strokeWidth: 1 }
+                          : false
+                      }
+                      activeDot={{ r: 5, fill: '#2563eb', stroke: '#2563eb' }}
+                      connectNulls
+                    />
+                    <Line
+                      yAxisId="ms"
+                      type="linear"
+                      dataKey="httpWaitingMs"
+                      name="HTTP waiting time"
+                      hide={!visibleSeries.httpWaitingMs}
+                      stroke="#f97316"
+                      strokeWidth={showPointsOnly ? 0.0001 : 2}
+                      dot={
+                        showPointsOnly
+                          ? { r: 3.5, fill: '#f97316', stroke: '#f97316', strokeWidth: 1 }
+                          : false
+                      }
+                      activeDot={{ r: 5, fill: '#f97316', stroke: '#f97316' }}
+                      connectNulls
+                    />
+                    <Line
+                      yAxisId="vus"
+                      type="linear"
+                      dataKey="vus"
+                      name="Virtual users"
+                      hide={!visibleSeries.vus}
+                      stroke="#16a34a"
+                      strokeWidth={showPointsOnly ? 0.0001 : 2}
+                      dot={
+                        showPointsOnly
+                          ? { r: 3.5, fill: '#16a34a', stroke: '#16a34a', strokeWidth: 1 }
+                          : false
+                      }
+                      activeDot={{ r: 5, fill: '#16a34a', stroke: '#16a34a' }}
+                      connectNulls
+                    />
+                    {k6ChartPoints.length > 1 ? (
+                      <Brush
+                        dataKey="timestampMs"
+                        startIndex={brushStartIndex}
+                        endIndex={brushEndIndex}
+                        onChange={handleBrushChange}
+                        tickFormatter={formatChartTickLabel}
+                        height={30}
+                        stroke="#64748b"
+                      />
+                    ) : null}
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+            </div>
+          )}
         </section>
 
         <section className="run-results-section">

--- a/src/features/benchmarks/charting.ts
+++ b/src/features/benchmarks/charting.ts
@@ -76,22 +76,28 @@ export function resolveYAxisDomain(
     return AUTO_DOMAIN
   }
 
-  const values: Array<number> = []
+  let min = Number.POSITIVE_INFINITY
+  let max = Number.NEGATIVE_INFINITY
+  let hasValue = false
+
   for (const point of points) {
     for (const metric of metrics) {
       const value = point[metric]
       if (value != null && !Number.isNaN(value)) {
-        values.push(value)
+        if (value < min) {
+          min = value
+        }
+        if (value > max) {
+          max = value
+        }
+        hasValue = true
       }
     }
   }
 
-  if (values.length === 0) {
+  if (!hasValue) {
     return AUTO_DOMAIN
   }
-
-  const min = Math.min(...values)
-  const max = Math.max(...values)
 
   if (mode === 'from-zero') {
     const paddedMax = max <= 0 ? 1 : max + Math.max(max * 0.05, 1)

--- a/src/features/benchmarks/charting.ts
+++ b/src/features/benchmarks/charting.ts
@@ -1,0 +1,153 @@
+import type { BenchmarkRunRawDTO } from '../../generated/openapi/models/BenchmarkRunRawDTO'
+import { formatReadableTimestamp } from '../dateTime'
+
+export type AxisScaleMode = 'auto' | 'from-zero' | 'tight'
+export type AxisDomain = [number | 'auto', number | 'auto']
+export type K6MetricKey = 'httpResponseTimeMs' | 'httpWaitingMs' | 'vus'
+
+export interface K6ChartPoint {
+  timestampMs: number
+  timestampLabel: string
+  httpResponseTimeMs: number | null
+  httpWaitingMs: number | null
+  vus: number | null
+}
+
+export const K6_MS_METRICS: ReadonlyArray<K6MetricKey> = [
+  'httpResponseTimeMs',
+  'httpWaitingMs',
+]
+export const K6_VUS_METRICS: ReadonlyArray<K6MetricKey> = ['vus']
+const K6_ALL_METRICS: ReadonlyArray<K6MetricKey> = [
+  'httpResponseTimeMs',
+  'httpWaitingMs',
+  'vus',
+]
+
+const AUTO_DOMAIN: AxisDomain = ['auto', 'auto']
+
+function toNumericValue(value: number | null | undefined): number | null {
+  if (value == null || Number.isNaN(value)) {
+    return null
+  }
+
+  return value
+}
+
+export function normalizeK6ChartPoints(rawData: BenchmarkRunRawDTO | null): Array<K6ChartPoint> {
+  const rawPoints = rawData?.timeSeries?.k6?.dataPoints ?? []
+  const points: Array<K6ChartPoint> = []
+
+  for (const point of rawPoints) {
+    const timestamp = point.timestamp ? new Date(point.timestamp) : null
+    if (!timestamp || Number.isNaN(timestamp.getTime())) {
+      continue
+    }
+
+    points.push({
+      timestampMs: timestamp.getTime(),
+      timestampLabel: formatReadableTimestamp(timestamp) ?? timestamp.toISOString(),
+      httpResponseTimeMs: toNumericValue(point.httpResponseTimeMs),
+      httpWaitingMs: toNumericValue(point.httpWaitingMs),
+      vus: toNumericValue(point.vus),
+    })
+  }
+
+  points.sort((a, b) => a.timestampMs - b.timestampMs)
+  return points
+}
+
+function withTightPadding(min: number, max: number): AxisDomain {
+  if (min === max) {
+    const padding = Math.max(Math.abs(min) * 0.1, 1)
+    return [min - padding, max + padding]
+  }
+
+  const padding = Math.max((max - min) * 0.08, 1)
+  return [min - padding, max + padding]
+}
+
+export function resolveYAxisDomain(
+  points: ReadonlyArray<K6ChartPoint>,
+  metrics: ReadonlyArray<K6MetricKey>,
+  mode: AxisScaleMode,
+): AxisDomain {
+  if (mode === 'auto') {
+    return AUTO_DOMAIN
+  }
+
+  const values: Array<number> = []
+  for (const point of points) {
+    for (const metric of metrics) {
+      const value = point[metric]
+      if (value != null && !Number.isNaN(value)) {
+        values.push(value)
+      }
+    }
+  }
+
+  if (values.length === 0) {
+    return AUTO_DOMAIN
+  }
+
+  const min = Math.min(...values)
+  const max = Math.max(...values)
+
+  if (mode === 'from-zero') {
+    const paddedMax = max <= 0 ? 1 : max + Math.max(max * 0.05, 1)
+    return [0, paddedMax]
+  }
+
+  return withTightPadding(min, max)
+}
+
+function averageMetric(
+  points: ReadonlyArray<K6ChartPoint>,
+  metric: K6MetricKey,
+  startIndex: number,
+  endIndex: number,
+): number | null {
+  let sum = 0
+  let count = 0
+
+  for (let index = startIndex; index <= endIndex; index += 1) {
+    const value = points[index]?.[metric]
+    if (value != null && !Number.isNaN(value)) {
+      sum += value
+      count += 1
+    }
+  }
+
+  if (count === 0) {
+    return null
+  }
+
+  return sum / count
+}
+
+export function applyK6SlidingAverage(
+  points: ReadonlyArray<K6ChartPoint>,
+  windowSize: number,
+): Array<K6ChartPoint> {
+  if (windowSize <= 1 || points.length === 0) {
+    return [...points]
+  }
+
+  const normalizedWindowSize = Math.max(Math.floor(windowSize), 1)
+  const leftWindowSize = Math.floor((normalizedWindowSize - 1) / 2)
+  const rightWindowSize = Math.ceil((normalizedWindowSize - 1) / 2)
+
+  return points.map((point, index) => {
+    const startIndex = Math.max(index - leftWindowSize, 0)
+    const endIndex = Math.min(index + rightWindowSize, points.length - 1)
+    const averagedPoint: K6ChartPoint = {
+      ...point,
+    }
+
+    for (const metric of K6_ALL_METRICS) {
+      averagedPoint[metric] = averageMetric(points, metric, startIndex, endIndex)
+    }
+
+    return averagedPoint
+  })
+}


### PR DESCRIPTION
## Summary
- add Recharts-based interactive K6 chart for run analysis
- add zoom, axis scale modes, line/points mode, legend toggles, and smoothing slider
- keep graceful fallback/raw sections and add chart helper utilities

## Testing
- npm run lint
- npm run build
- npm run test

Closes #23