### PR TITLE
feat: Compare two benchmark runs side-by-side (#70)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -679,6 +679,39 @@
   border-bottom: 0;
 }
 
+.benchmark-details-compare-col {
+  width: 1px;
+  white-space: nowrap;
+  text-align: center !important;
+  padding-left: 0.4rem !important;
+  padding-right: 0.4rem !important;
+}
+
+.benchmark-details-compare-col input[type='checkbox'] {
+  width: 1.35rem;
+  height: 1.35rem;
+  cursor: pointer;
+  accent-color: var(--btn-primary-bg, #2563eb);
+}
+
+.benchmark-compare-header-button {
+  display: inline-block;
+  padding: 0.25rem 0.6rem;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #fff;
+  background: var(--btn-primary-bg, #2563eb);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  white-space: nowrap;
+  line-height: 1.4;
+}
+
+.benchmark-compare-header-button:hover {
+  background: var(--btn-primary-hover, #1d4ed8);
+}
+
 .benchmark-details-run-actions {
   display: flex;
   gap: 0.5rem;

--- a/src/App.css
+++ b/src/App.css
@@ -1904,6 +1904,51 @@
   max-width: 640px;
 }
 
+.run-comparison-percentile-selector {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.run-comparison-percentile-label {
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: #475569;
+  margin-right: 0.3rem;
+}
+
+.run-comparison-percentile-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.7rem;
+  font-size: 0.82rem;
+  font-weight: 500;
+  border: 1px solid #cbd5e1;
+  border-radius: 999px;
+  background: #fff;
+  color: #475569;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.run-comparison-percentile-pill:hover {
+  border-color: #94a3b8;
+  background: #f1f5f9;
+}
+
+.run-comparison-percentile-pill.active {
+  background: #2563eb;
+  border-color: #2563eb;
+  color: #fff;
+}
+
+.run-comparison-percentile-pill.active:hover {
+  background: #1d4ed8;
+  border-color: #1d4ed8;
+}
+
 @media (max-width: 768px) {
   .run-comparison-metadata {
     grid-template-columns: 1fr;

--- a/src/App.css
+++ b/src/App.css
@@ -694,6 +694,11 @@
   accent-color: var(--btn-primary-bg, #2563eb);
 }
 
+.benchmark-details-compare-col input[type='checkbox']:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
 .benchmark-compare-header-button {
   display: inline-block;
   padding: 0.25rem 0.6rem;

--- a/src/App.css
+++ b/src/App.css
@@ -1781,3 +1781,135 @@
     transform: rotate(360deg);
   }
 }
+
+/* ── Run comparison page ───────────────────────── */
+
+.run-comparison-breadcrumb {
+  font-size: 0.88rem;
+  color: #64748b;
+  margin-bottom: 1rem;
+}
+
+.run-comparison-breadcrumb a {
+  color: var(--btn-primary-bg, #2563eb);
+  text-decoration: none;
+}
+
+.run-comparison-breadcrumb a:hover {
+  text-decoration: underline;
+}
+
+.run-comparison-metadata {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.2rem;
+  margin-bottom: 1.5rem;
+}
+
+.run-comparison-run-card {
+  border: 1px solid #d4e1f3;
+  border-radius: 8px;
+  padding: 1rem 1.2rem;
+  background: #f9fbff;
+}
+
+.run-comparison-run-a {
+  border-left: 4px solid #2563eb;
+}
+
+.run-comparison-run-b {
+  border-left: 4px solid #9333ea;
+}
+
+.run-comparison-run-card h3 {
+  margin: 0 0 0.6rem;
+  font-size: 1rem;
+}
+
+.run-comparison-run-id {
+  font-weight: 400;
+  color: #64748b;
+  font-size: 0.88rem;
+}
+
+.run-comparison-meta-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 0.6rem;
+}
+
+.run-comparison-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+}
+
+.run-comparison-table th,
+.run-comparison-table td {
+  text-align: left;
+  padding: 0.5rem 0.7rem;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.run-comparison-table th {
+  background: #f3f8ff;
+  font-size: 0.86rem;
+}
+
+.run-comparison-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.run-comparison-col-a {
+  color: #2563eb;
+  font-weight: 500;
+}
+
+.run-comparison-col-b {
+  color: #9333ea;
+  font-weight: 500;
+}
+
+.run-comparison-delta-improvement {
+  color: #16a34a;
+  font-weight: 500;
+}
+
+.run-comparison-delta-regression {
+  color: #dc2626;
+  font-weight: 500;
+}
+
+.run-comparison-http-group {
+  margin-bottom: 1.5rem;
+}
+
+.run-comparison-http-group h3 {
+  margin: 0 0 0.5rem;
+  font-size: 0.95rem;
+}
+
+.run-comparison-hosts {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.2rem;
+}
+
+.run-comparison-host-panel h3 {
+  margin: 0 0 0.5rem;
+  font-size: 0.95rem;
+}
+
+.run-comparison-vus-grid {
+  max-width: 640px;
+}
+
+@media (max-width: 768px) {
+  .run-comparison-metadata {
+    grid-template-columns: 1fr;
+  }
+
+  .run-comparison-hosts {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { BenchmarkFormPage } from './features/benchmarks/BenchmarkFormPage'
 import { BenchmarkRunMonitorPage } from './features/benchmarks/BenchmarkRunMonitorPage'
 import { BenchmarkRunResultsPage } from './features/benchmarks/BenchmarkRunResultsPage'
 import { BenchmarkDetailsPage } from './features/benchmarks/BenchmarkDetailsPage'
+import { BenchmarkRunComparisonPage } from './features/benchmarks/BenchmarkRunComparisonPage'
 import './App.css'
 
 function App() {
@@ -40,6 +41,10 @@ function App() {
           <Route
             path="/environments/:environmentId/benchmarks/:benchmarkId"
             element={<BenchmarkDetailsPage />}
+          />
+          <Route
+            path="/environments/:environmentId/benchmarks/:benchmarkId/compare/:runIdA/:runIdB"
+            element={<BenchmarkRunComparisonPage />}
           />
           <Route
             path="/environments/:environmentId/benchmarks/:benchmarkId/runs/:runId"

--- a/src/features/benchmarks/BenchmarkDetailsPage.tsx
+++ b/src/features/benchmarks/BenchmarkDetailsPage.tsx
@@ -167,6 +167,10 @@ export function BenchmarkDetailsPage() {
   const [actionNotice, setActionNotice] = useState<string | null>(null)
   const [selectedRunIds, setSelectedRunIds] = useState<Array<string>>([])
 
+  // Clear run selections when navigating to a different benchmark
+  useEffect(() => {
+    setSelectedRunIds([])
+  }, [environmentId, benchmarkId])
   const toggleRunSelection = (runId: string) => {
     setSelectedRunIds((current) => {
       if (current.includes(runId)) {
@@ -611,18 +615,20 @@ export function BenchmarkDetailsPage() {
 
                     return (
                       <tr key={runId || `benchmark-run-${index}`}>
-                        <td className="benchmark-details-compare-col">
+                        <td
+                          className="benchmark-details-compare-col"
+                          title={
+                            !isFinished
+                              ? 'Only finished runs can be compared'
+                              : canCompare && !isSelected
+                                ? 'Only two runs can be compared at a time — deselect one first'
+                                : undefined
+                          }
+                        >
                           <input
                             type="checkbox"
                             checked={isSelected}
                             disabled={!runId || !isFinished || (canCompare && !isSelected)}
-                            title={
-                              !isFinished
-                                ? 'Only finished runs can be compared'
-                                : canCompare && !isSelected
-                                  ? 'Only two runs can be compared at a time — deselect one first'
-                                  : undefined
-                            }
                             onChange={() => { if (runId) toggleRunSelection(runId) }}
                           />
                         </td>

--- a/src/features/benchmarks/BenchmarkDetailsPage.tsx
+++ b/src/features/benchmarks/BenchmarkDetailsPage.tsx
@@ -165,6 +165,21 @@ export function BenchmarkDetailsPage() {
   >({})
   const [actionError, setActionError] = useState<string | null>(null)
   const [actionNotice, setActionNotice] = useState<string | null>(null)
+  const [selectedRunIds, setSelectedRunIds] = useState<Array<string>>([])
+
+  const toggleRunSelection = (runId: string) => {
+    setSelectedRunIds((current) => {
+      if (current.includes(runId)) {
+        return current.filter((id) => id !== runId)
+      }
+      if (current.length >= 2) {
+        return current
+      }
+      return [...current, runId]
+    })
+  }
+
+  const canCompare = selectedRunIds.length === 2
 
   const load = useCallback(
     async (signal: AbortSignal) => {
@@ -551,6 +566,23 @@ export function BenchmarkDetailsPage() {
               <table className="benchmark-details-runs-table">
                 <thead>
                   <tr>
+                    <th className="benchmark-details-compare-col">
+                      {canCompare ? (
+                        <button
+                          type="button"
+                          className="benchmark-compare-header-button"
+                          onClick={() =>
+                            navigate(
+                              `/environments/${environmentId}/benchmarks/${benchmarkId}/compare/${selectedRunIds[0]}/${selectedRunIds[1]}`,
+                            )
+                          }
+                        >
+                          Compare
+                        </button>
+                      ) : (
+                        'Compare'
+                      )}
+                    </th>
                     <th>Run start</th>
                     <th>Run end / total</th>
                     <th>Status</th>
@@ -574,9 +606,26 @@ export function BenchmarkDetailsPage() {
                       : undefined
                     const startedAt = run.startedAt ?? run.createdAt
                     const runDetailsLabel = getRunDetailsLabel(run.status)
+                    const isFinished = isResultsSummaryStatus(run.status)
+                    const isSelected = Boolean(runId && selectedRunIds.includes(runId))
 
                     return (
                       <tr key={runId || `benchmark-run-${index}`}>
+                        <td className="benchmark-details-compare-col">
+                          <input
+                            type="checkbox"
+                            checked={isSelected}
+                            disabled={!runId || !isFinished || (canCompare && !isSelected)}
+                            title={
+                              !isFinished
+                                ? 'Only finished runs can be compared'
+                                : canCompare && !isSelected
+                                  ? 'Only two runs can be compared at a time — deselect one first'
+                                  : undefined
+                            }
+                            onChange={() => { if (runId) toggleRunSelection(runId) }}
+                          />
+                        </td>
                         <td>{formatTimestamp(startedAt)}</td>
                         <td>{formatEndedWithRuntime(run)}</td>
                         <td>

--- a/src/features/benchmarks/BenchmarkRunComparisonPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunComparisonPage.tsx
@@ -152,22 +152,20 @@ function matchHttpGroups(
   return Array.from(map.entries()).map(([groupName, pair]) => ({ groupName, ...pair }))
 }
 
-const RUN_A_COLOR = '#2563eb'
-const RUN_B_COLOR = '#9333ea'
-
 const SERIES_CONFIG: Array<{
   dataKey: ComparisonMetricKey
   name: string
   yAxisId: string
   color: string
-  dashed: boolean
+  dashPattern?: string
+  width: number
 }> = [
-  { dataKey: 'httpResponseTimeMs_A', name: 'HTTP response (A)', yAxisId: 'ms', color: RUN_A_COLOR, dashed: false },
-  { dataKey: 'httpResponseTimeMs_B', name: 'HTTP response (B)', yAxisId: 'ms', color: RUN_B_COLOR, dashed: true },
-  { dataKey: 'httpWaitingMs_A', name: 'HTTP waiting (A)', yAxisId: 'ms', color: '#1d4ed8', dashed: false },
-  { dataKey: 'httpWaitingMs_B', name: 'HTTP waiting (B)', yAxisId: 'ms', color: '#7c3aed', dashed: true },
-  { dataKey: 'vus_A', name: 'VUs (A)', yAxisId: 'vus', color: '#16a34a', dashed: false },
-  { dataKey: 'vus_B', name: 'VUs (B)', yAxisId: 'vus', color: '#15803d', dashed: true },
+  { dataKey: 'httpResponseTimeMs_A', name: 'HTTP response (A)', yAxisId: 'ms', color: '#2563eb', width: 2 },
+  { dataKey: 'httpResponseTimeMs_B', name: 'HTTP response (B)', yAxisId: 'ms', color: '#dc2626', dashPattern: '10 4', width: 2.5 },
+  { dataKey: 'httpWaitingMs_A', name: 'HTTP waiting (A)', yAxisId: 'ms', color: '#60a5fa', width: 2 },
+  { dataKey: 'httpWaitingMs_B', name: 'HTTP waiting (B)', yAxisId: 'ms', color: '#f97316', dashPattern: '10 4', width: 2.5 },
+  { dataKey: 'vus_A', name: 'VUs (A)', yAxisId: 'vus', color: '#16a34a', width: 2 },
+  { dataKey: 'vus_B', name: 'VUs (B)', yAxisId: 'vus', color: '#a855f7', dashPattern: '10 4', width: 2.5 },
 ]
 
 export function BenchmarkRunComparisonPage() {
@@ -569,8 +567,8 @@ export function BenchmarkRunComparisonPage() {
                         name={series.name}
                         hide={!visibleSeries[series.dataKey]}
                         stroke={series.color}
-                        strokeWidth={showPointsOnly ? 0.0001 : 2}
-                        strokeDasharray={series.dashed ? '6 3' : undefined}
+                        strokeWidth={showPointsOnly ? 0.0001 : series.width}
+                        strokeDasharray={series.dashPattern}
                         dot={
                           showPointsOnly
                             ? { r: 3.5, fill: series.color, stroke: series.color, strokeWidth: 1 }

--- a/src/features/benchmarks/BenchmarkRunComparisonPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunComparisonPage.tsx
@@ -194,6 +194,7 @@ export function BenchmarkRunComparisonPage() {
   const [smoothingLevel, setSmoothingLevel] = useState(0)
   const [visibleSeries, setVisibleSeries] = useState<ComparisonSeriesVisibility>(DEFAULT_SERIES_VISIBILITY)
   const [brushRange, setBrushRange] = useState<BrushRange | null>(null)
+  const [selectedPercentiles, setSelectedPercentiles] = useState<Set<string> | null>(null)
 
   const environmentLabel = (environmentName ?? environmentId).trim() || 'n/a'
   const benchmarkLabel = (benchmarkName ?? benchmarkId).trim() || 'n/a'
@@ -260,6 +261,34 @@ export function BenchmarkRunComparisonPage() {
 
   const matchedHttpGroups = useMemo(() => matchHttpGroups(httpA, httpB), [httpA, httpB])
   const percentileKeys = useMemo(() => collectPercentileKeys(httpA, httpB), [httpA, httpB])
+
+  // Default to all percentiles selected once data loads
+  const activePercentiles = useMemo(
+    () => selectedPercentiles ?? new Set(percentileKeys),
+    [selectedPercentiles, percentileKeys],
+  )
+  const visiblePercentileKeys = useMemo(
+    () => percentileKeys.filter((k) => activePercentiles.has(k)),
+    [percentileKeys, activePercentiles],
+  )
+
+  function togglePercentile(key: string) {
+    const next = new Set(activePercentiles)
+    if (next.has(key)) {
+      next.delete(key)
+    } else {
+      next.add(key)
+    }
+    setSelectedPercentiles(next)
+  }
+
+  function toggleAllPercentiles() {
+    if (activePercentiles.size === percentileKeys.length) {
+      setSelectedPercentiles(new Set())
+    } else {
+      setSelectedPercentiles(new Set(percentileKeys))
+    }
+  }
 
   const baseChartPoints = useMemo(
     () => mergeK6ChartPointsByElapsed(comparisonData?.rawA ?? null, comparisonData?.rawB ?? null),
@@ -602,6 +631,28 @@ export function BenchmarkRunComparisonPage() {
         {/* HTTP statistics comparison */}
         <section className="run-results-section">
           <h2>HTTP comparison</h2>
+          {percentileKeys.length > 0 && (
+            <div className="run-comparison-percentile-selector">
+              <span className="run-comparison-percentile-label">Percentiles:</span>
+              <button
+                type="button"
+                className={`run-comparison-percentile-pill ${activePercentiles.size === percentileKeys.length ? 'active' : ''}`}
+                onClick={toggleAllPercentiles}
+              >
+                All
+              </button>
+              {percentileKeys.map((pKey) => (
+                <button
+                  key={pKey}
+                  type="button"
+                  className={`run-comparison-percentile-pill ${activePercentiles.has(pKey) ? 'active' : ''}`}
+                  onClick={() => togglePercentile(pKey)}
+                >
+                  {pKey}
+                </button>
+              ))}
+            </div>
+          )}
           {matchedHttpGroups.length === 0 ? (
             <p className="run-results-placeholder">
               No HTTP metrics available for comparison.
@@ -675,7 +726,7 @@ export function BenchmarkRunComparisonPage() {
                         <td className="run-comparison-col-b">{formatMetric(b?.duration?.median, ' ms')}</td>
                         <td className={deltaClass(a?.duration?.median, b?.duration?.median)}>{formatDelta(a?.duration?.median, b?.duration?.median, 'ms')}</td>
                       </tr>
-                      {percentileKeys.map((pKey) => (
+                      {visiblePercentileKeys.map((pKey) => (
                         <tr key={pKey}>
                           <td>{pKey} duration</td>
                           <td className="run-comparison-col-a">{formatMetric(a?.duration?.percentiles?.[pKey], ' ms')}</td>

--- a/src/features/benchmarks/BenchmarkRunComparisonPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunComparisonPage.tsx
@@ -1,4 +1,174 @@
-import { useParams } from 'react-router-dom'
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import {
+  Brush,
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import type { DerivedHttpSummaryDTO } from '../../generated/openapi/models/DerivedHttpSummaryDTO'
+import { getEnvironmentDetails } from '../environments/service'
+import { AsyncStateView } from '../ui/async-state/AsyncState'
+import type { AxisScaleMode } from './charting'
+import {
+  applyComparisonSlidingAverage,
+  COMPARISON_MS_METRICS,
+  COMPARISON_VUS_METRICS,
+  type ComparisonMetricKey,
+  mergeK6ChartPointsByElapsed,
+  resolveComparisonYAxisDomain,
+} from './comparisonCharting'
+import {
+  BenchmarkRunDetailsError,
+  getBenchmark,
+  getComparisonData,
+  type ComparisonRunData,
+} from './service'
+import {
+  formatDelta,
+  formatRunStatus,
+  formatRuntimeDuration,
+  formatTimestamp,
+} from './format'
+
+function formatMetric(value?: number, unit = ''): string {
+  if (value == null || Number.isNaN(value)) return 'n/a'
+  return `${value.toFixed(2)}${unit}`
+}
+
+function formatRatePercent(value?: number): string {
+  if (value == null || Number.isNaN(value)) return 'n/a'
+  return `${(value * 100).toFixed(2)}%`
+}
+
+function formatBytes(value?: number): string {
+  if (value == null || Number.isNaN(value)) return 'n/a'
+  if (value <= 0) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let size = value
+  let unitIndex = 0
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024
+    unitIndex += 1
+  }
+  return `${size.toFixed(size >= 100 ? 0 : size >= 10 ? 1 : 2)} ${units[unitIndex]}`
+}
+
+const AXIS_MODE_OPTIONS: Array<{ value: AxisScaleMode; label: string; description: string }> = [
+  { value: 'auto', label: 'Auto', description: 'Automatic Y-axis scaling.' },
+  { value: 'from-zero', label: 'From-zero', description: 'Y-axis starts at zero.' },
+  { value: 'tight', label: 'Tight', description: 'Y-axis fits closely around visible data.' },
+]
+
+type ChartRenderMode = 'line' | 'points'
+
+const CHART_RENDER_MODE_OPTIONS: Array<{ value: ChartRenderMode; label: string; description: string }> = [
+  { value: 'line', label: 'Line', description: 'Connected line chart.' },
+  { value: 'points', label: 'Points', description: 'Points-only chart rendering.' },
+]
+
+type ComparisonSeriesVisibility = Record<ComparisonMetricKey, boolean>
+
+const DEFAULT_SERIES_VISIBILITY: ComparisonSeriesVisibility = {
+  httpResponseTimeMs_A: true,
+  httpWaitingMs_A: true,
+  vus_A: true,
+  httpResponseTimeMs_B: true,
+  httpWaitingMs_B: true,
+  vus_B: true,
+}
+
+type BrushRange = { startIndex: number; endIndex: number }
+type BrushChangeEvent = { startIndex?: number; endIndex?: number }
+
+function toComparisonMetricKey(value: unknown): ComparisonMetricKey | null {
+  const valid: ReadonlyArray<ComparisonMetricKey> = [
+    ...COMPARISON_MS_METRICS,
+    ...COMPARISON_VUS_METRICS,
+  ]
+  return valid.includes(value as ComparisonMetricKey) ? (value as ComparisonMetricKey) : null
+}
+
+function formatComparisonTooltipValue(
+  value: number | string | ReadonlyArray<number | string> | null | undefined,
+  name: number | string | undefined,
+): [string, string] {
+  const label = typeof name === 'undefined' ? 'Value' : String(name)
+  const normalizedValue = Array.isArray(value) ? value[0] : value
+  if (typeof normalizedValue !== 'number' || Number.isNaN(normalizedValue)) {
+    return ['n/a', label]
+  }
+  if (label.includes('VUs')) {
+    return [normalizedValue.toFixed(0), label]
+  }
+  return [`${normalizedValue.toFixed(2)} ms`, label]
+}
+
+function collectPercentileKeys(
+  httpA: Array<DerivedHttpSummaryDTO>,
+  httpB: Array<DerivedHttpSummaryDTO>,
+): Array<string> {
+  const keys = new Set<string>()
+  for (const metric of [...httpA, ...httpB]) {
+    if (metric.duration?.percentiles) {
+      for (const key of Object.keys(metric.duration.percentiles)) {
+        keys.add(key)
+      }
+    }
+    if (metric.waiting?.percentiles) {
+      for (const key of Object.keys(metric.waiting.percentiles)) {
+        keys.add(key)
+      }
+    }
+  }
+  return Array.from(keys).sort()
+}
+
+function matchHttpGroups(
+  httpA: Array<DerivedHttpSummaryDTO>,
+  httpB: Array<DerivedHttpSummaryDTO>,
+): Array<{ groupName: string; a: DerivedHttpSummaryDTO | null; b: DerivedHttpSummaryDTO | null }> {
+  const map = new Map<string, { a: DerivedHttpSummaryDTO | null; b: DerivedHttpSummaryDTO | null }>()
+
+  for (const metric of httpA) {
+    const key = metric.requestGroup ?? metric.url ?? 'default'
+    map.set(key, { a: metric, b: null })
+  }
+  for (const metric of httpB) {
+    const key = metric.requestGroup ?? metric.url ?? 'default'
+    const existing = map.get(key)
+    if (existing) {
+      existing.b = metric
+    } else {
+      map.set(key, { a: null, b: metric })
+    }
+  }
+
+  return Array.from(map.entries()).map(([groupName, pair]) => ({ groupName, ...pair }))
+}
+
+const RUN_A_COLOR = '#2563eb'
+const RUN_B_COLOR = '#9333ea'
+
+const SERIES_CONFIG: Array<{
+  dataKey: ComparisonMetricKey
+  name: string
+  yAxisId: string
+  color: string
+  dashed: boolean
+}> = [
+  { dataKey: 'httpResponseTimeMs_A', name: 'HTTP response (A)', yAxisId: 'ms', color: RUN_A_COLOR, dashed: false },
+  { dataKey: 'httpResponseTimeMs_B', name: 'HTTP response (B)', yAxisId: 'ms', color: RUN_B_COLOR, dashed: true },
+  { dataKey: 'httpWaitingMs_A', name: 'HTTP waiting (A)', yAxisId: 'ms', color: '#1d4ed8', dashed: false },
+  { dataKey: 'httpWaitingMs_B', name: 'HTTP waiting (B)', yAxisId: 'ms', color: '#7c3aed', dashed: true },
+  { dataKey: 'vus_A', name: 'VUs (A)', yAxisId: 'vus', color: '#16a34a', dashed: false },
+  { dataKey: 'vus_B', name: 'VUs (B)', yAxisId: 'vus', color: '#15803d', dashed: true },
+]
 
 export function BenchmarkRunComparisonPage() {
   const {
@@ -12,17 +182,572 @@ export function BenchmarkRunComparisonPage() {
     runIdA: string
     runIdB: string
   }>()
+  const navigate = useNavigate()
+
+  const [environmentName, setEnvironmentName] = useState<string | null>(null)
+  const [benchmarkName, setBenchmarkName] = useState<string | null>(null)
+  const [comparisonData, setComparisonData] = useState<ComparisonRunData | null>(null)
+  const [fatalError, setFatalError] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [retryAttempt, setRetryAttempt] = useState(0)
+
+  const [axisScaleMode, setAxisScaleMode] = useState<AxisScaleMode>('auto')
+  const [chartRenderMode, setChartRenderMode] = useState<ChartRenderMode>('line')
+  const [smoothingLevel, setSmoothingLevel] = useState(0)
+  const [visibleSeries, setVisibleSeries] = useState<ComparisonSeriesVisibility>(DEFAULT_SERIES_VISIBILITY)
+  const [brushRange, setBrushRange] = useState<BrushRange | null>(null)
+
+  const environmentLabel = (environmentName ?? environmentId).trim() || 'n/a'
+  const benchmarkLabel = (benchmarkName ?? benchmarkId).trim() || 'n/a'
+  const benchmarkPath = `/environments/${environmentId}/benchmarks/${benchmarkId}`
+
+  useEffect(() => {
+    if (!environmentId.trim() || !benchmarkId.trim() || !runIdA.trim() || !runIdB.trim()) {
+      setFatalError('Missing required route parameters.')
+      setIsLoading(false)
+      return
+    }
+
+    const controller = new AbortController()
+    setIsLoading(true)
+    setFatalError(null)
+    setComparisonData(null)
+
+    const load = async () => {
+      const [envResult, bmResult, compResult] = await Promise.allSettled([
+        getEnvironmentDetails(environmentId, controller.signal),
+        getBenchmark(environmentId, benchmarkId, controller.signal),
+        getComparisonData(environmentId, benchmarkId, runIdA, runIdB, controller.signal),
+      ])
+
+      if (controller.signal.aborted) return
+
+      setEnvironmentName(
+        envResult.status === 'fulfilled'
+          ? envResult.value.name?.trim() || environmentId
+          : environmentId,
+      )
+      setBenchmarkName(
+        bmResult.status === 'fulfilled'
+          ? bmResult.value.name?.trim() || benchmarkId
+          : benchmarkId,
+      )
+
+      if (compResult.status === 'fulfilled') {
+        setComparisonData(compResult.value)
+      } else {
+        const err = compResult.reason
+        setFatalError(
+          err instanceof BenchmarkRunDetailsError
+            ? err.message
+            : 'Failed to load comparison data. Please try again.',
+        )
+      }
+
+      setIsLoading(false)
+    }
+
+    void load()
+    return () => controller.abort()
+  }, [benchmarkId, environmentId, retryAttempt, runIdA, runIdB])
+
+  const runA = comparisonData?.derivedA?.run
+  const runB = comparisonData?.derivedB?.run
+  const httpA = useMemo(() => [...(comparisonData?.derivedA?.http ?? [])].sort((a, b) => (b.totalRequests ?? 0) - (a.totalRequests ?? 0)), [comparisonData])
+  const httpB = useMemo(() => [...(comparisonData?.derivedB?.http ?? [])].sort((a, b) => (b.totalRequests ?? 0) - (a.totalRequests ?? 0)), [comparisonData])
+  const vusA = comparisonData?.derivedA?.vus
+  const vusB = comparisonData?.derivedB?.vus
+  const hostsA = useMemo(() => [...(comparisonData?.derivedA?.hosts ?? [])].sort((a, b) => (a.hostName ?? '').localeCompare(b.hostName ?? '')), [comparisonData])
+  const hostsB = useMemo(() => [...(comparisonData?.derivedB?.hosts ?? [])].sort((a, b) => (a.hostName ?? '').localeCompare(b.hostName ?? '')), [comparisonData])
+
+  const matchedHttpGroups = useMemo(() => matchHttpGroups(httpA, httpB), [httpA, httpB])
+  const percentileKeys = useMemo(() => collectPercentileKeys(httpA, httpB), [httpA, httpB])
+
+  const baseChartPoints = useMemo(
+    () => mergeK6ChartPointsByElapsed(comparisonData?.rawA ?? null, comparisonData?.rawB ?? null),
+    [comparisonData],
+  )
+  const smoothingWindowSize = smoothingLevel === 0 ? 1 : smoothingLevel + 1
+  const chartPoints = useMemo(
+    () => applyComparisonSlidingAverage(baseChartPoints, smoothingWindowSize),
+    [baseChartPoints, smoothingWindowSize],
+  )
+
+  const maxBrushIndex = Math.max(chartPoints.length - 1, 0)
+  const brushStartIndex = Math.min(Math.max(brushRange?.startIndex ?? 0, 0), maxBrushIndex)
+  const brushEndIndex = Math.min(Math.max(brushRange?.endIndex ?? maxBrushIndex, brushStartIndex), maxBrushIndex)
+  const visibleChartPoints = useMemo(() => {
+    if (chartPoints.length === 0) return []
+    return chartPoints.slice(brushStartIndex, brushEndIndex + 1)
+  }, [brushEndIndex, brushStartIndex, chartPoints])
+
+  const msAxisDomain = useMemo(
+    () => resolveComparisonYAxisDomain(visibleChartPoints, COMPARISON_MS_METRICS, axisScaleMode),
+    [axisScaleMode, visibleChartPoints],
+  )
+  const vusAxisDomain = useMemo(
+    () => resolveComparisonYAxisDomain(visibleChartPoints, COMPARISON_VUS_METRICS, axisScaleMode),
+    [axisScaleMode, visibleChartPoints],
+  )
+
+  useEffect(() => {
+    if (chartPoints.length === 0) {
+      setBrushRange(null)
+      return
+    }
+    setBrushRange({ startIndex: 0, endIndex: chartPoints.length - 1 })
+  }, [baseChartPoints, chartPoints.length, runIdA, runIdB])
+
+  const showPointsOnly = chartRenderMode === 'points'
+  const isZoomed = chartPoints.length > 1 && (brushStartIndex > 0 || brushEndIndex < chartPoints.length - 1)
+
+  const handleBrushChange = (nextRange: BrushChangeEvent) => {
+    if (chartPoints.length === 0) return
+    if (typeof nextRange.startIndex !== 'number' || typeof nextRange.endIndex !== 'number') return
+    const maxIndex = chartPoints.length - 1
+    const startIndex = Math.min(Math.max(nextRange.startIndex, 0), maxIndex)
+    const endIndex = Math.min(Math.max(nextRange.endIndex, startIndex), maxIndex)
+    setBrushRange({ startIndex, endIndex })
+  }
+
+  const handleResetZoom = () => {
+    if (chartPoints.length === 0) { setBrushRange(null); return }
+    setBrushRange({ startIndex: 0, endIndex: chartPoints.length - 1 })
+  }
+
+  const handleLegendClick = (entry: unknown) => {
+    if (!entry || typeof entry !== 'object' || !('dataKey' in entry)) return
+    const dataKey = toComparisonMetricKey((entry as { dataKey?: unknown }).dataKey)
+    if (!dataKey) return
+    setVisibleSeries((current) => ({ ...current, [dataKey]: !current[dataKey] }))
+  }
+
+  const runIdAShort = runIdA.slice(0, 8)
+  const runIdBShort = runIdB.slice(0, 8)
 
   return (
-    <article className="run-comparison-page">
-      <h1>Run Comparison</h1>
-      <p>
-        Comparing runs <strong>{runIdA.slice(0, 8)}</strong> and{' '}
-        <strong>{runIdB.slice(0, 8)}</strong> from benchmark{' '}
-        <strong>{benchmarkId.slice(0, 8)}</strong> in environment{' '}
-        <strong>{environmentId.slice(0, 8)}</strong>.
-      </p>
-      <p>Full comparison view coming in Phase 2.</p>
+    <article className="shell-page">
+      <div className="run-results-top-row">
+        <div>
+          <h1>Run comparison</h1>
+          <p className="auth-text run-results-byline">
+            Comparing <strong>Run A</strong> ({runIdAShort}) vs <strong>Run B</strong> ({runIdBShort})
+          </p>
+        </div>
+        <button type="button" className="shell-alert-dismiss" onClick={() => navigate(benchmarkPath)}>
+          Back to benchmark
+        </button>
+      </div>
+
+      <AsyncStateView
+        isLoading={isLoading}
+        error={fatalError}
+        isEmpty={false}
+        onRetry={() => setRetryAttempt((c) => c + 1)}
+        loadingTitle="Loading comparison data"
+      >
+        {/* Breadcrumb */}
+        <nav className="run-comparison-breadcrumb">
+          <Link to="/environments">Environments</Link>
+          {' / '}
+          <Link to={`/environments/${environmentId}`}>{environmentLabel}</Link>
+          {' / '}
+          <Link to={benchmarkPath}>{benchmarkLabel}</Link>
+          {' / '}
+          <span>Compare</span>
+        </nav>
+
+        {/* Metadata header */}
+        <section className="run-comparison-metadata">
+          <div className="run-comparison-run-card run-comparison-run-a">
+            <h3>Run A <span className="run-comparison-run-id">({runIdAShort})</span></h3>
+            <div className="run-comparison-meta-grid">
+              <div>
+                <p className="shell-context-label">Status</p>
+                <p className="shell-context-value">{formatRunStatus(runA?.status)}</p>
+              </div>
+              <div>
+                <p className="shell-context-label">Started</p>
+                <p className="shell-context-value">{formatTimestamp(runA?.startedAt)}</p>
+              </div>
+              <div>
+                <p className="shell-context-label">Ended</p>
+                <p className="shell-context-value">{formatTimestamp(runA?.finishedAt)}</p>
+              </div>
+              <div>
+                <p className="shell-context-label">Duration</p>
+                <p className="shell-context-value">{formatRuntimeDuration(runA?.startedAt, runA?.finishedAt) ?? 'n/a'}</p>
+              </div>
+              <div>
+                <p className="shell-context-label">Started by</p>
+                <p className="shell-context-value">{runA?.startedBy?.trim() || 'n/a'}</p>
+              </div>
+            </div>
+          </div>
+          <div className="run-comparison-run-card run-comparison-run-b">
+            <h3>Run B <span className="run-comparison-run-id">({runIdBShort})</span></h3>
+            <div className="run-comparison-meta-grid">
+              <div>
+                <p className="shell-context-label">Status</p>
+                <p className="shell-context-value">{formatRunStatus(runB?.status)}</p>
+              </div>
+              <div>
+                <p className="shell-context-label">Started</p>
+                <p className="shell-context-value">{formatTimestamp(runB?.startedAt)}</p>
+              </div>
+              <div>
+                <p className="shell-context-label">Ended</p>
+                <p className="shell-context-value">{formatTimestamp(runB?.finishedAt)}</p>
+              </div>
+              <div>
+                <p className="shell-context-label">Duration</p>
+                <p className="shell-context-value">{formatRuntimeDuration(runB?.startedAt, runB?.finishedAt) ?? 'n/a'}</p>
+              </div>
+              <div>
+                <p className="shell-context-label">Started by</p>
+                <p className="shell-context-value">{runB?.startedBy?.trim() || 'n/a'}</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* VUs comparison */}
+        <section className="run-results-section">
+          <h2>Virtual users</h2>
+          <div className="run-comparison-vus-grid">
+            <table className="run-comparison-table">
+              <thead>
+                <tr>
+                  <th>Metric</th>
+                  <th className="run-comparison-col-a">Run A</th>
+                  <th className="run-comparison-col-b">Run B</th>
+                  <th>Delta</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Avg</td>
+                  <td className="run-comparison-col-a">{formatMetric(vusA?.avg)}</td>
+                  <td className="run-comparison-col-b">{formatMetric(vusB?.avg)}</td>
+                  <td className={deltaClass(vusA?.avg, vusB?.avg)}>{formatDelta(vusA?.avg, vusB?.avg)}</td>
+                </tr>
+                <tr>
+                  <td>Min</td>
+                  <td className="run-comparison-col-a">{formatMetric(vusA?.min)}</td>
+                  <td className="run-comparison-col-b">{formatMetric(vusB?.min)}</td>
+                  <td className={deltaClass(vusA?.min, vusB?.min)}>{formatDelta(vusA?.min, vusB?.min)}</td>
+                </tr>
+                <tr>
+                  <td>Max</td>
+                  <td className="run-comparison-col-a">{formatMetric(vusA?.max)}</td>
+                  <td className="run-comparison-col-b">{formatMetric(vusB?.max)}</td>
+                  <td className={deltaClass(vusA?.max, vusB?.max)}>{formatDelta(vusA?.max, vusB?.max)}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Overlay charts */}
+        <section className="run-results-section">
+          <h2>Chart comparison</h2>
+          {chartPoints.length === 0 ? (
+            <p className="run-results-placeholder">
+              Time-series data is not available for one or both runs.
+            </p>
+          ) : (
+            <div className="run-results-chart-shell">
+              <div className="run-results-chart-controls">
+                <div className="run-results-axis-mode-group" role="group" aria-label="Y-axis scale">
+                  {AXIS_MODE_OPTIONS.map((option) => (
+                    <button
+                      key={option.value}
+                      type="button"
+                      className={`shell-alert-dismiss run-results-axis-mode-button${axisScaleMode === option.value ? ' is-selected' : ''}`}
+                      onClick={() => setAxisScaleMode(option.value)}
+                      aria-pressed={axisScaleMode === option.value}
+                      title={option.description}
+                    >
+                      {option.label}
+                    </button>
+                  ))}
+                </div>
+                <div className="run-results-axis-mode-group" role="group" aria-label="Chart render mode">
+                  {CHART_RENDER_MODE_OPTIONS.map((option) => (
+                    <button
+                      key={option.value}
+                      type="button"
+                      className={`shell-alert-dismiss run-results-axis-mode-button${chartRenderMode === option.value ? ' is-selected' : ''}`}
+                      onClick={() => setChartRenderMode(option.value)}
+                      aria-pressed={chartRenderMode === option.value}
+                      title={option.description}
+                    >
+                      {option.label}
+                    </button>
+                  ))}
+                </div>
+                <div className="run-results-smoothing-slider-group">
+                  <label className="run-results-smoothing-slider-label" htmlFor="comparison-smoothing-slider">
+                    Sliding average: {smoothingLevel === 0 ? 'Raw' : smoothingLevel}
+                  </label>
+                  <input
+                    id="comparison-smoothing-slider"
+                    className="run-results-smoothing-slider-input"
+                    type="range"
+                    min={0}
+                    max={9}
+                    step={1}
+                    value={smoothingLevel}
+                    onChange={(e) => {
+                      const next = Number(e.currentTarget.value)
+                      if (!Number.isNaN(next)) setSmoothingLevel(Math.min(Math.max(next, 0), 9))
+                    }}
+                    aria-label="Sliding average level from 0 to 9"
+                  />
+                  <div className="run-results-smoothing-slider-marks" aria-hidden="true">
+                    <span>Raw</span>
+                    <span>5</span>
+                    <span>9</span>
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  className="shell-alert-dismiss run-results-chart-reset"
+                  onClick={handleResetZoom}
+                  disabled={!isZoomed}
+                >
+                  Reset zoom
+                </button>
+              </div>
+
+              <div className="run-results-chart-container">
+                <ResponsiveContainer width="100%" height="100%">
+                  <LineChart data={chartPoints} margin={{ top: 12, right: 8, left: 0, bottom: 4 }}>
+                    <CartesianGrid stroke="#d9e2ef" strokeDasharray="3 3" />
+                    <XAxis
+                      dataKey="elapsedMs"
+                      type="number"
+                      domain={['dataMin', 'dataMax']}
+                      minTickGap={42}
+                      tickFormatter={(v: number) => {
+                        const s = Math.floor(v / 1000)
+                        const m = Math.floor(s / 60)
+                        return m > 0 ? `${m}m ${(s % 60).toString().padStart(2, '0')}s` : `${s}s`
+                      }}
+                      label={{ value: 'Elapsed time', position: 'insideBottomRight', offset: -4 }}
+                    />
+                    <YAxis
+                      yAxisId="ms"
+                      domain={msAxisDomain}
+                      tickFormatter={(v: number) => `${Math.round(v)} ms`}
+                      width={68}
+                    />
+                    <YAxis
+                      yAxisId="vus"
+                      orientation="right"
+                      domain={vusAxisDomain}
+                      tickFormatter={(v: number) => `${Math.round(v)}`}
+                      width={46}
+                    />
+                    <Tooltip
+                      formatter={formatComparisonTooltipValue}
+                      labelFormatter={(label: unknown) => {
+                        if (typeof label !== 'number') return String(label)
+                        const s = Math.floor(label / 1000)
+                        const m = Math.floor(s / 60)
+                        return m > 0 ? `Elapsed: ${m}m ${(s % 60).toString().padStart(2, '0')}s` : `Elapsed: ${s}s`
+                      }}
+                      isAnimationActive={false}
+                    />
+                    <Legend onClick={handleLegendClick} />
+                    {SERIES_CONFIG.map((series) => (
+                      <Line
+                        key={series.dataKey}
+                        yAxisId={series.yAxisId}
+                        type="linear"
+                        dataKey={series.dataKey}
+                        name={series.name}
+                        hide={!visibleSeries[series.dataKey]}
+                        stroke={series.color}
+                        strokeWidth={showPointsOnly ? 0.0001 : 2}
+                        strokeDasharray={series.dashed ? '6 3' : undefined}
+                        dot={
+                          showPointsOnly
+                            ? { r: 3.5, fill: series.color, stroke: series.color, strokeWidth: 1 }
+                            : false
+                        }
+                        activeDot={{ r: 5, fill: series.color, stroke: series.color }}
+                        connectNulls
+                      />
+                    ))}
+                    {chartPoints.length > 1 ? (
+                      <Brush
+                        dataKey="elapsedMs"
+                        startIndex={brushStartIndex}
+                        endIndex={brushEndIndex}
+                        onChange={handleBrushChange}
+                        tickFormatter={(v: number) => {
+                          const s = Math.floor(v / 1000)
+                          return s >= 60 ? `${Math.floor(s / 60)}m` : `${s}s`
+                        }}
+                        height={30}
+                        stroke="#64748b"
+                      />
+                    ) : null}
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+            </div>
+          )}
+        </section>
+
+        {/* HTTP statistics comparison */}
+        <section className="run-results-section">
+          <h2>HTTP comparison</h2>
+          {matchedHttpGroups.length === 0 ? (
+            <p className="run-results-placeholder">
+              No HTTP metrics available for comparison.
+            </p>
+          ) : (
+            matchedHttpGroups.map(({ groupName, a, b }) => (
+              <div key={groupName} className="run-comparison-http-group">
+                <h3>{groupName}</h3>
+                <div className="run-results-table-wrap">
+                  <table className="run-comparison-table">
+                    <thead>
+                      <tr>
+                        <th>Metric</th>
+                        <th className="run-comparison-col-a">Run A</th>
+                        <th className="run-comparison-col-b">Run B</th>
+                        <th>Delta</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td>Total requests</td>
+                        <td className="run-comparison-col-a">{a?.totalRequests ?? 'n/a'}</td>
+                        <td className="run-comparison-col-b">{b?.totalRequests ?? 'n/a'}</td>
+                        <td className={deltaClass(a?.totalRequests, b?.totalRequests)}>{formatDelta(a?.totalRequests, b?.totalRequests)}</td>
+                      </tr>
+                      <tr>
+                        <td>Requests/s</td>
+                        <td className="run-comparison-col-a">{formatMetric(a?.requestsPerSecond)}</td>
+                        <td className="run-comparison-col-b">{formatMetric(b?.requestsPerSecond)}</td>
+                        <td className={deltaClass(a?.requestsPerSecond, b?.requestsPerSecond)}>{formatDelta(a?.requestsPerSecond, b?.requestsPerSecond)}</td>
+                      </tr>
+                      <tr>
+                        <td>Error rate</td>
+                        <td className="run-comparison-col-a">{formatRatePercent(a?.errorRate)}</td>
+                        <td className="run-comparison-col-b">{formatRatePercent(b?.errorRate)}</td>
+                        <td className={deltaClass(a?.errorRate, b?.errorRate)}>{formatDelta(a?.errorRate, b?.errorRate)}</td>
+                      </tr>
+                      <tr>
+                        <td>Data received</td>
+                        <td className="run-comparison-col-a">{formatBytes(a?.totalDataReceivedBytes)}</td>
+                        <td className="run-comparison-col-b">{formatBytes(b?.totalDataReceivedBytes)}</td>
+                        <td className={deltaClass(a?.totalDataReceivedBytes, b?.totalDataReceivedBytes)}>{formatDelta(a?.totalDataReceivedBytes, b?.totalDataReceivedBytes, 'B')}</td>
+                      </tr>
+                      <tr>
+                        <td>Data sent</td>
+                        <td className="run-comparison-col-a">{formatBytes(a?.totalDataSentBytes)}</td>
+                        <td className="run-comparison-col-b">{formatBytes(b?.totalDataSentBytes)}</td>
+                        <td className={deltaClass(a?.totalDataSentBytes, b?.totalDataSentBytes)}>{formatDelta(a?.totalDataSentBytes, b?.totalDataSentBytes, 'B')}</td>
+                      </tr>
+                      <tr>
+                        <td>Avg duration</td>
+                        <td className="run-comparison-col-a">{formatMetric(a?.duration?.avg, ' ms')}</td>
+                        <td className="run-comparison-col-b">{formatMetric(b?.duration?.avg, ' ms')}</td>
+                        <td className={deltaClass(a?.duration?.avg, b?.duration?.avg)}>{formatDelta(a?.duration?.avg, b?.duration?.avg, 'ms')}</td>
+                      </tr>
+                      <tr>
+                        <td>Min duration</td>
+                        <td className="run-comparison-col-a">{formatMetric(a?.duration?.min, ' ms')}</td>
+                        <td className="run-comparison-col-b">{formatMetric(b?.duration?.min, ' ms')}</td>
+                        <td className={deltaClass(a?.duration?.min, b?.duration?.min)}>{formatDelta(a?.duration?.min, b?.duration?.min, 'ms')}</td>
+                      </tr>
+                      <tr>
+                        <td>Max duration</td>
+                        <td className="run-comparison-col-a">{formatMetric(a?.duration?.max, ' ms')}</td>
+                        <td className="run-comparison-col-b">{formatMetric(b?.duration?.max, ' ms')}</td>
+                        <td className={deltaClass(a?.duration?.max, b?.duration?.max)}>{formatDelta(a?.duration?.max, b?.duration?.max, 'ms')}</td>
+                      </tr>
+                      <tr>
+                        <td>Median duration</td>
+                        <td className="run-comparison-col-a">{formatMetric(a?.duration?.median, ' ms')}</td>
+                        <td className="run-comparison-col-b">{formatMetric(b?.duration?.median, ' ms')}</td>
+                        <td className={deltaClass(a?.duration?.median, b?.duration?.median)}>{formatDelta(a?.duration?.median, b?.duration?.median, 'ms')}</td>
+                      </tr>
+                      {percentileKeys.map((pKey) => (
+                        <tr key={pKey}>
+                          <td>{pKey} duration</td>
+                          <td className="run-comparison-col-a">{formatMetric(a?.duration?.percentiles?.[pKey], ' ms')}</td>
+                          <td className="run-comparison-col-b">{formatMetric(b?.duration?.percentiles?.[pKey], ' ms')}</td>
+                          <td className={deltaClass(a?.duration?.percentiles?.[pKey], b?.duration?.percentiles?.[pKey])}>
+                            {formatDelta(a?.duration?.percentiles?.[pKey], b?.duration?.percentiles?.[pKey], 'ms')}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            ))
+          )}
+        </section>
+
+        {/* Host resources comparison */}
+        <section className="run-results-section">
+          <h2>Host resources</h2>
+          {hostsA.length === 0 && hostsB.length === 0 ? (
+            <p className="run-results-placeholder">
+              No host resource data available for comparison.
+            </p>
+          ) : (
+            <div className="run-comparison-hosts">
+              <div className="run-comparison-host-panel">
+                <h3>Run A hosts</h3>
+                {hostsA.length === 0 ? (
+                  <p>No host data available.</p>
+                ) : (
+                  <ul className="run-results-host-list">
+                    {hostsA.map((host) => (
+                      <li key={`a-${host.hostId ?? host.hostName ?? ''}`}>
+                        <h4>{host.hostName ?? host.hostId ?? 'Host'}</h4>
+                        <p>CPU avg {formatMetric(host.resource?.cpu?.avg, '%')} | Mem avg {formatMetric(host.resource?.memory?.avg, '%')}</p>
+                        <p>Net in {formatBytes(host.resource?.networkInTotalBytes)} | Net out {formatBytes(host.resource?.networkOutTotalBytes)}</p>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+              <div className="run-comparison-host-panel">
+                <h3>Run B hosts</h3>
+                {hostsB.length === 0 ? (
+                  <p>No host data available.</p>
+                ) : (
+                  <ul className="run-results-host-list">
+                    {hostsB.map((host) => (
+                      <li key={`b-${host.hostId ?? host.hostName ?? ''}`}>
+                        <h4>{host.hostName ?? host.hostId ?? 'Host'}</h4>
+                        <p>CPU avg {formatMetric(host.resource?.cpu?.avg, '%')} | Mem avg {formatMetric(host.resource?.memory?.avg, '%')}</p>
+                        <p>Net in {formatBytes(host.resource?.networkInTotalBytes)} | Net out {formatBytes(host.resource?.networkOutTotalBytes)}</p>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </div>
+          )}
+        </section>
+      </AsyncStateView>
     </article>
   )
+}
+
+function deltaClass(a: number | undefined | null, b: number | undefined | null): string {
+  if (a == null || b == null || Number.isNaN(a) || Number.isNaN(b)) return ''
+  const diff = b - a
+  if (diff > 0) return 'run-comparison-delta-regression'
+  if (diff < 0) return 'run-comparison-delta-improvement'
+  return ''
 }

--- a/src/features/benchmarks/BenchmarkRunComparisonPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunComparisonPage.tsx
@@ -120,36 +120,42 @@ function collectPercentileKeys(
         keys.add(key)
       }
     }
-    if (metric.waiting?.percentiles) {
-      for (const key of Object.keys(metric.waiting.percentiles)) {
-        keys.add(key)
-      }
-    }
   }
   return Array.from(keys).sort()
+}
+
+function getHttpGroupMatchKey(metric: DerivedHttpSummaryDTO): string {
+  return `${metric.requestGroup ?? ''}|${metric.url ?? ''}`
+}
+
+function getHttpGroupDisplayName(metric: DerivedHttpSummaryDTO): string {
+  return metric.requestGroup ?? metric.url ?? 'default'
 }
 
 function matchHttpGroups(
   httpA: Array<DerivedHttpSummaryDTO>,
   httpB: Array<DerivedHttpSummaryDTO>,
 ): Array<{ groupName: string; a: DerivedHttpSummaryDTO | null; b: DerivedHttpSummaryDTO | null }> {
-  const map = new Map<string, { a: DerivedHttpSummaryDTO | null; b: DerivedHttpSummaryDTO | null }>()
+  const map = new Map<
+    string,
+    { groupName: string; a: DerivedHttpSummaryDTO | null; b: DerivedHttpSummaryDTO | null }
+  >()
 
   for (const metric of httpA) {
-    const key = metric.requestGroup ?? metric.url ?? 'default'
-    map.set(key, { a: metric, b: null })
+    const key = getHttpGroupMatchKey(metric)
+    map.set(key, { groupName: getHttpGroupDisplayName(metric), a: metric, b: null })
   }
   for (const metric of httpB) {
-    const key = metric.requestGroup ?? metric.url ?? 'default'
+    const key = getHttpGroupMatchKey(metric)
     const existing = map.get(key)
     if (existing) {
       existing.b = metric
     } else {
-      map.set(key, { a: null, b: metric })
+      map.set(key, { groupName: getHttpGroupDisplayName(metric), a: null, b: metric })
     }
   }
 
-  return Array.from(map.entries()).map(([groupName, pair]) => ({ groupName, ...pair }))
+  return Array.from(map.values())
 }
 
 const SERIES_CONFIG: Array<{
@@ -203,6 +209,12 @@ export function BenchmarkRunComparisonPage() {
   useEffect(() => {
     if (!environmentId.trim() || !benchmarkId.trim() || !runIdA.trim() || !runIdB.trim()) {
       setFatalError('Missing required route parameters.')
+      setIsLoading(false)
+      return
+    }
+
+    if (runIdA.trim() === runIdB.trim()) {
+      setFatalError('Please select two different benchmark runs to compare.')
       setIsLoading(false)
       return
     }
@@ -676,13 +688,13 @@ export function BenchmarkRunComparisonPage() {
                         <td>Total requests</td>
                         <td className="run-comparison-col-a">{a?.totalRequests ?? 'n/a'}</td>
                         <td className="run-comparison-col-b">{b?.totalRequests ?? 'n/a'}</td>
-                        <td className={deltaClass(a?.totalRequests, b?.totalRequests)}>{formatDelta(a?.totalRequests, b?.totalRequests)}</td>
+                        <td className={deltaClass(a?.totalRequests, b?.totalRequests, true)}>{formatDelta(a?.totalRequests, b?.totalRequests)}</td>
                       </tr>
                       <tr>
                         <td>Requests/s</td>
                         <td className="run-comparison-col-a">{formatMetric(a?.requestsPerSecond)}</td>
                         <td className="run-comparison-col-b">{formatMetric(b?.requestsPerSecond)}</td>
-                        <td className={deltaClass(a?.requestsPerSecond, b?.requestsPerSecond)}>{formatDelta(a?.requestsPerSecond, b?.requestsPerSecond)}</td>
+                        <td className={deltaClass(a?.requestsPerSecond, b?.requestsPerSecond, true)}>{formatDelta(a?.requestsPerSecond, b?.requestsPerSecond)}</td>
                       </tr>
                       <tr>
                         <td>Error rate</td>
@@ -793,10 +805,16 @@ export function BenchmarkRunComparisonPage() {
   )
 }
 
-function deltaClass(a: number | undefined | null, b: number | undefined | null): string {
+function deltaClass(
+  a: number | undefined | null,
+  b: number | undefined | null,
+  higherIsBetter = false,
+): string {
   if (a == null || b == null || Number.isNaN(a) || Number.isNaN(b)) return ''
   const diff = b - a
-  if (diff > 0) return 'run-comparison-delta-regression'
-  if (diff < 0) return 'run-comparison-delta-improvement'
-  return ''
+  if (diff === 0) return ''
+  const isImprovement = higherIsBetter ? diff > 0 : diff < 0
+  return isImprovement
+    ? 'run-comparison-delta-improvement'
+    : 'run-comparison-delta-regression'
 }

--- a/src/features/benchmarks/BenchmarkRunComparisonPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunComparisonPage.tsx
@@ -1,0 +1,28 @@
+import { useParams } from 'react-router-dom'
+
+export function BenchmarkRunComparisonPage() {
+  const {
+    environmentId = '',
+    benchmarkId = '',
+    runIdA = '',
+    runIdB = '',
+  } = useParams<{
+    environmentId: string
+    benchmarkId: string
+    runIdA: string
+    runIdB: string
+  }>()
+
+  return (
+    <article className="run-comparison-page">
+      <h1>Run Comparison</h1>
+      <p>
+        Comparing runs <strong>{runIdA.slice(0, 8)}</strong> and{' '}
+        <strong>{runIdB.slice(0, 8)}</strong> from benchmark{' '}
+        <strong>{benchmarkId.slice(0, 8)}</strong> in environment{' '}
+        <strong>{environmentId.slice(0, 8)}</strong>.
+      </p>
+      <p>Full comparison view coming in Phase 2.</p>
+    </article>
+  )
+}

--- a/src/features/benchmarks/comparisonCharting.ts
+++ b/src/features/benchmarks/comparisonCharting.ts
@@ -1,0 +1,193 @@
+import type { BenchmarkRunRawDTO } from '../../generated/openapi/models/BenchmarkRunRawDTO'
+import {
+  type AxisDomain,
+  type AxisScaleMode,
+  type K6ChartPoint,
+  normalizeK6ChartPoints,
+} from './charting'
+
+export interface ComparisonChartPoint {
+  elapsedMs: number
+  elapsedLabel: string
+  httpResponseTimeMs_A: number | null
+  httpWaitingMs_A: number | null
+  vus_A: number | null
+  httpResponseTimeMs_B: number | null
+  httpWaitingMs_B: number | null
+  vus_B: number | null
+}
+
+export type ComparisonMetricKey =
+  | 'httpResponseTimeMs_A'
+  | 'httpWaitingMs_A'
+  | 'vus_A'
+  | 'httpResponseTimeMs_B'
+  | 'httpWaitingMs_B'
+  | 'vus_B'
+
+export const COMPARISON_MS_METRICS: ReadonlyArray<ComparisonMetricKey> = [
+  'httpResponseTimeMs_A',
+  'httpWaitingMs_A',
+  'httpResponseTimeMs_B',
+  'httpWaitingMs_B',
+]
+
+export const COMPARISON_VUS_METRICS: ReadonlyArray<ComparisonMetricKey> = [
+  'vus_A',
+  'vus_B',
+]
+
+function formatElapsedLabel(elapsedMs: number): string {
+  const totalSeconds = Math.floor(elapsedMs / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  if (minutes > 0) {
+    return `${minutes}m ${seconds.toString().padStart(2, '0')}s`
+  }
+  return `${seconds}s`
+}
+
+function toElapsedPoints(points: ReadonlyArray<K6ChartPoint>): Array<{ elapsedMs: number; point: K6ChartPoint }> {
+  if (points.length === 0) return []
+  const baseMs = points[0].timestampMs
+  return points.map((p) => ({
+    elapsedMs: p.timestampMs - baseMs,
+    point: p,
+  }))
+}
+
+export function mergeK6ChartPointsByElapsed(
+  rawA: BenchmarkRunRawDTO | null,
+  rawB: BenchmarkRunRawDTO | null,
+): Array<ComparisonChartPoint> {
+  const pointsA = normalizeK6ChartPoints(rawA)
+  const pointsB = normalizeK6ChartPoints(rawB)
+
+  const elapsedA = toElapsedPoints(pointsA)
+  const elapsedB = toElapsedPoints(pointsB)
+
+  const merged = new Map<number, ComparisonChartPoint>()
+
+  for (const { elapsedMs, point } of elapsedA) {
+    merged.set(elapsedMs, {
+      elapsedMs,
+      elapsedLabel: formatElapsedLabel(elapsedMs),
+      httpResponseTimeMs_A: point.httpResponseTimeMs,
+      httpWaitingMs_A: point.httpWaitingMs,
+      vus_A: point.vus,
+      httpResponseTimeMs_B: null,
+      httpWaitingMs_B: null,
+      vus_B: null,
+    })
+  }
+
+  for (const { elapsedMs, point } of elapsedB) {
+    const existing = merged.get(elapsedMs)
+    if (existing) {
+      existing.httpResponseTimeMs_B = point.httpResponseTimeMs
+      existing.httpWaitingMs_B = point.httpWaitingMs
+      existing.vus_B = point.vus
+    } else {
+      merged.set(elapsedMs, {
+        elapsedMs,
+        elapsedLabel: formatElapsedLabel(elapsedMs),
+        httpResponseTimeMs_A: null,
+        httpWaitingMs_A: null,
+        vus_A: null,
+        httpResponseTimeMs_B: point.httpResponseTimeMs,
+        httpWaitingMs_B: point.httpWaitingMs,
+        vus_B: point.vus,
+      })
+    }
+  }
+
+  return Array.from(merged.values()).sort((a, b) => a.elapsedMs - b.elapsedMs)
+}
+
+function withTightPadding(min: number, max: number): AxisDomain {
+  if (min === max) {
+    const padding = Math.max(Math.abs(min) * 0.1, 1)
+    return [min - padding, max + padding]
+  }
+
+  const padding = Math.max((max - min) * 0.08, 1)
+  return [min - padding, max + padding]
+}
+
+const AUTO_DOMAIN: AxisDomain = ['auto', 'auto']
+
+export function resolveComparisonYAxisDomain(
+  points: ReadonlyArray<ComparisonChartPoint>,
+  metrics: ReadonlyArray<ComparisonMetricKey>,
+  mode: AxisScaleMode,
+): AxisDomain {
+  if (mode === 'auto') {
+    return AUTO_DOMAIN
+  }
+
+  let min = Number.POSITIVE_INFINITY
+  let max = Number.NEGATIVE_INFINITY
+  let hasValue = false
+
+  for (const point of points) {
+    for (const metric of metrics) {
+      const value = point[metric]
+      if (value != null && !Number.isNaN(value)) {
+        if (value < min) min = value
+        if (value > max) max = value
+        hasValue = true
+      }
+    }
+  }
+
+  if (!hasValue) {
+    return AUTO_DOMAIN
+  }
+
+  if (mode === 'from-zero') {
+    const paddedMax = max <= 0 ? 1 : max + Math.max(max * 0.05, 1)
+    return [0, paddedMax]
+  }
+
+  return withTightPadding(min, max)
+}
+
+export function applyComparisonSlidingAverage(
+  points: ReadonlyArray<ComparisonChartPoint>,
+  windowSize: number,
+): Array<ComparisonChartPoint> {
+  if (windowSize <= 1 || points.length === 0) {
+    return [...points]
+  }
+
+  const ALL_METRICS: ReadonlyArray<ComparisonMetricKey> = [
+    ...COMPARISON_MS_METRICS,
+    ...COMPARISON_VUS_METRICS,
+  ]
+
+  const normalizedWindowSize = Math.max(Math.floor(windowSize), 1)
+  const leftWindowSize = Math.floor((normalizedWindowSize - 1) / 2)
+  const rightWindowSize = Math.ceil((normalizedWindowSize - 1) / 2)
+
+  return points.map((point, index) => {
+    const startIndex = Math.max(index - leftWindowSize, 0)
+    const endIndex = Math.min(index + rightWindowSize, points.length - 1)
+
+    const averaged: ComparisonChartPoint = { ...point }
+
+    for (const metric of ALL_METRICS) {
+      let sum = 0
+      let count = 0
+      for (let i = startIndex; i <= endIndex; i += 1) {
+        const value = points[i][metric]
+        if (value != null && !Number.isNaN(value)) {
+          sum += value
+          count += 1
+        }
+      }
+      averaged[metric] = count > 0 ? sum / count : null
+    }
+
+    return averaged
+  })
+}

--- a/src/features/benchmarks/domain/errors.ts
+++ b/src/features/benchmarks/domain/errors.ts
@@ -143,3 +143,12 @@ export class BenchmarkRunRawError extends BenchmarkDomainError {
   }
 }
 
+export class BenchmarkRunComparisonError extends BenchmarkDomainError {
+  constructor(message: string, metadata: BenchmarkDomainErrorMetadata = {}) {
+    super('BenchmarkRunComparisonError', message, {
+      operation: 'get-run-details',
+      ...metadata,
+    })
+  }
+}
+

--- a/src/features/benchmarks/domain/errors.ts
+++ b/src/features/benchmarks/domain/errors.ts
@@ -16,6 +16,7 @@ export type BenchmarkDomainOperation =
   | 'delete-run'
   | 'get-run-details'
   | 'get-run-raw'
+  | 'get-run-comparison'
   | 'list-runs'
   | 'list-environment-runs'
   | 'unknown'
@@ -146,7 +147,7 @@ export class BenchmarkRunRawError extends BenchmarkDomainError {
 export class BenchmarkRunComparisonError extends BenchmarkDomainError {
   constructor(message: string, metadata: BenchmarkDomainErrorMetadata = {}) {
     super('BenchmarkRunComparisonError', message, {
-      operation: 'get-run-details',
+      operation: 'get-run-comparison',
       ...metadata,
     })
   }

--- a/src/features/benchmarks/domain/index.ts
+++ b/src/features/benchmarks/domain/index.ts
@@ -35,4 +35,5 @@ export {
   listActiveEnvironmentRuns,
   getComparisonData,
 } from './services/runService'
+export type { ComparisonRunData } from './services/runService'
 

--- a/src/features/benchmarks/domain/index.ts
+++ b/src/features/benchmarks/domain/index.ts
@@ -11,6 +11,7 @@ export {
   DeleteBenchmarkRunError,
   BenchmarkRunDetailsError,
   BenchmarkRunRawError,
+  BenchmarkRunComparisonError,
   isBenchmarkDomainError,
 } from './errors'
 export type {
@@ -32,5 +33,6 @@ export {
   getBenchmarkRunRaw,
   listBenchmarkRuns,
   listActiveEnvironmentRuns,
+  getComparisonData,
 } from './services/runService'
 

--- a/src/features/benchmarks/domain/services/runService.ts
+++ b/src/features/benchmarks/domain/services/runService.ts
@@ -3,7 +3,7 @@ import type { BenchmarkRunDTO } from '../../../../generated/openapi/models/Bench
 import type { BenchmarkRunRawDTO } from '../../../../generated/openapi/models/BenchmarkRunRawDTO'
 import type { BenchmarkStatusDTO } from '../../../../generated/openapi/models/BenchmarkStatusDTO'
 import type { EnvironmentRunSummaryDTO } from '../../../../generated/openapi/models/EnvironmentRunSummaryDTO'
-import { BenchmarkRunDetailsError, BenchmarkRunsLoadError } from '../errors'
+import { BenchmarkRunDetailsError, BenchmarkRunComparisonError, BenchmarkRunsLoadError } from '../errors'
 import {
   deleteBenchmarkRunGateway,
   getBenchmarkRunDetailsGateway,
@@ -122,6 +122,44 @@ export async function listActiveEnvironmentRuns(
       {
         kind: 'network',
         operation: 'list-environment-runs',
+        cause: error,
+      },
+    )
+  }
+}
+
+export interface ComparisonRunData {
+  derivedA: BenchmarkRunDerivedDTO
+  derivedB: BenchmarkRunDerivedDTO
+  rawA: BenchmarkRunRawDTO | null
+  rawB: BenchmarkRunRawDTO | null
+}
+
+export async function getComparisonData(
+  environmentId: string,
+  benchmarkId: string,
+  runIdA: string,
+  runIdB: string,
+  signal?: AbortSignal,
+): Promise<ComparisonRunData> {
+  try {
+    const [derivedA, derivedB, rawA, rawB] = await Promise.all([
+      getBenchmarkRunDetails(environmentId, benchmarkId, runIdA, signal),
+      getBenchmarkRunDetails(environmentId, benchmarkId, runIdB, signal),
+      getBenchmarkRunRaw(environmentId, benchmarkId, runIdA, signal).catch(() => null),
+      getBenchmarkRunRaw(environmentId, benchmarkId, runIdB, signal).catch(() => null),
+    ])
+
+    return { derivedA, derivedB, rawA, rawB }
+  } catch (error: unknown) {
+    if (error instanceof BenchmarkRunDetailsError) {
+      throw error
+    }
+
+    throw new BenchmarkRunComparisonError(
+      'Failed to load comparison data. Please try again.',
+      {
+        kind: 'network',
         cause: error,
       },
     )

--- a/src/features/benchmarks/format.ts
+++ b/src/features/benchmarks/format.ts
@@ -22,6 +22,8 @@ export function formatDelta(
     const percent = Math.abs((diff / a) * 100)
     const arrow = diff > 0 ? '▲' : diff < 0 ? '▼' : ''
     percentPart = arrow ? ` (${arrow} ${percent.toFixed(1)}%)` : ' (0.0%)'
+  } else {
+    percentPart = ' (n/a)'
   }
 
   return `${sign}${absDiff.toFixed(2)}${unit ? ` ${unit}` : ''}${percentPart}`

--- a/src/features/benchmarks/format.ts
+++ b/src/features/benchmarks/format.ts
@@ -4,6 +4,29 @@ export function formatTimestamp(value?: Date | string): string {
   return formatReadableTimestamp(value) ?? 'n/a'
 }
 
+export function formatDelta(
+  a: number | undefined | null,
+  b: number | undefined | null,
+  unit = '',
+): string {
+  if (a == null || b == null || Number.isNaN(a) || Number.isNaN(b)) {
+    return 'n/a'
+  }
+
+  const diff = b - a
+  const sign = diff >= 0 ? '+' : '−'
+  const absDiff = Math.abs(diff)
+
+  let percentPart = ''
+  if (a !== 0) {
+    const percent = Math.abs((diff / a) * 100)
+    const arrow = diff > 0 ? '▲' : diff < 0 ? '▼' : ''
+    percentPart = arrow ? ` (${arrow} ${percent.toFixed(1)}%)` : ' (0.0%)'
+  }
+
+  return `${sign}${absDiff.toFixed(2)}${unit ? ` ${unit}` : ''}${percentPart}`
+}
+
 export function formatRunStatus(status?: string): string {
   if (!status) {
     return 'Unknown'

--- a/src/features/benchmarks/service.ts
+++ b/src/features/benchmarks/service.ts
@@ -33,5 +33,5 @@ export {
   listActiveEnvironmentRuns,
   getComparisonData,
 } from './domain'
-export type { ComparisonRunData } from './domain/services/runService'
+export type { ComparisonRunData } from './domain'
 

--- a/src/features/benchmarks/service.ts
+++ b/src/features/benchmarks/service.ts
@@ -11,6 +11,7 @@ export {
   DeleteBenchmarkRunError,
   BenchmarkRunDetailsError,
   BenchmarkRunRawError,
+  BenchmarkRunComparisonError,
   isBenchmarkDomainError,
 } from './domain'
 export type {
@@ -30,5 +31,7 @@ export {
   getBenchmarkRunRaw,
   listBenchmarkRuns,
   listActiveEnvironmentRuns,
+  getComparisonData,
 } from './domain'
+export type { ComparisonRunData } from './domain/services/runService'
 


### PR DESCRIPTION
## Summary

Implements the **Compare two benchmark runs** feature (closes #70).

### Run selection (Phase 1)
- Checkbox column on the benchmark details runs table (max 2 finished runs)
- Column header becomes a **Compare** button when exactly 2 runs are selected
- Remaining checkboxes disabled with tooltip when 2 are already selected

### Comparison page (Phase 2)
- **Breadcrumb** navigation back to environment/benchmark
- **Metadata cards** — side-by-side Run A / Run B with status, timestamps, duration, started-by
- **Overlay chart** — elapsed-time X-axis with 6 line series (HTTP response, HTTP waiting, VUs × 2 runs)
  - Highly distinct colours: Run A = solid (blue, light-blue, green); Run B = dashed (red, orange, purple)
  - All existing controls: axis mode, render mode, smoothing slider, brush zoom, legend toggles
- **Percentile selector** — toggle pills to show/hide specific percentiles in HTTP tables
- **HTTP comparison tables** — per request-group with Run A / Run B / Delta columns, delta colouring (green = improvement, red = regression)
- **VUs comparison table** with delta indicators
- **Host resources** side-by-side panels
- Responsive layout with mobile breakpoint

### Technical details
- Elapsed-time alignment merges two runs started at different times
- Parallel data fetching with graceful degradation for raw data
- \ormatDelta(a, b, unit)\ with ▲/▼ arrows and percentage