### PR TITLE
feat(ui): scrollable benchmark instructions with show more/less (#65)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -615,7 +615,29 @@
   overflow: auto;
   font-size: 0.87rem;
   line-height: 1.5;
-  max-height: 360px;
+  max-height: 220px;
+  transition: max-height 0.25s ease;
+}
+
+.benchmark-details-code-block.expanded {
+  max-height: none;
+}
+
+.benchmark-details-instructions-toggle {
+  display: block;
+  margin: 0.4rem auto 0;
+  padding: 0.2rem 0.8rem;
+  font-size: 0.82rem;
+  color: #475569;
+  background: none;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.benchmark-details-instructions-toggle:hover {
+  background: #f1f5f9;
+  border-color: #94a3b8;
 }
 
 .benchmark-details-code-block code {

--- a/src/features/benchmarks/BenchmarkDetailsPage.tsx
+++ b/src/features/benchmarks/BenchmarkDetailsPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useLocation, useNavigate, useParams } from 'react-router-dom'
 import { getEnvironmentDetails } from '../environments/service'
 import { AsyncStateView } from '../ui/async-state/AsyncState'
@@ -166,11 +166,22 @@ export function BenchmarkDetailsPage() {
   const [actionError, setActionError] = useState<string | null>(null)
   const [actionNotice, setActionNotice] = useState<string | null>(null)
   const [selectedRunIds, setSelectedRunIds] = useState<Array<string>>([])
-
+  const [instructionsExpanded, setInstructionsExpanded] = useState(false)
+  const codeBlockRef = useRef<HTMLPreElement>(null)
+  const [instructionsOverflow, setInstructionsOverflow] = useState(false)
   // Clear run selections when navigating to a different benchmark
   useEffect(() => {
     setSelectedRunIds([])
   }, [environmentId, benchmarkId])
+
+  // Detect whether the instructions code block overflows its max-height
+  useEffect(() => {
+    const el = codeBlockRef.current
+    if (el) {
+      setInstructionsOverflow(el.scrollHeight > el.clientHeight)
+    }
+  }, [instructions])
+
   const toggleRunSelection = (runId: string) => {
     setSelectedRunIds((current) => {
       if (current.includes(runId)) {
@@ -538,7 +549,10 @@ export function BenchmarkDetailsPage() {
 
           <section className="benchmark-details-section benchmark-details-instructions-section">
             <div className="benchmark-details-instructions-shell">
-              <pre className="benchmark-details-code-block">
+              <pre
+                ref={codeBlockRef}
+                className={`benchmark-details-code-block${instructionsExpanded ? ' expanded' : ''}`}
+              >
                 <code>
                   {instructionTokens.map((token, index) => (
                     <span
@@ -550,6 +564,15 @@ export function BenchmarkDetailsPage() {
                   ))}
                 </code>
               </pre>
+              {(instructionsOverflow || instructionsExpanded) && (
+                <button
+                  type="button"
+                  className="benchmark-details-instructions-toggle"
+                  onClick={() => setInstructionsExpanded((v) => !v)}
+                >
+                  {instructionsExpanded ? 'Show less' : 'Show more'}
+                </button>
+              )}
             </div>
           </section>
         </section>

--- a/src/features/benchmarks/BenchmarkDetailsPage.tsx
+++ b/src/features/benchmarks/BenchmarkDetailsPage.tsx
@@ -169,18 +169,23 @@ export function BenchmarkDetailsPage() {
   const [instructionsExpanded, setInstructionsExpanded] = useState(false)
   const codeBlockRef = useRef<HTMLPreElement>(null)
   const [instructionsOverflow, setInstructionsOverflow] = useState(false)
-  // Clear run selections when navigating to a different benchmark
+  // Clear run selections and reset instructions expansion when navigating to a different benchmark
   useEffect(() => {
     setSelectedRunIds([])
+    setInstructionsExpanded(false)
   }, [environmentId, benchmarkId])
 
-  // Detect whether the instructions code block overflows its max-height
+  // Detect whether the instructions code block overflows its collapsed max-height
   useEffect(() => {
+    if (instructionsExpanded) {
+      return
+    }
+
     const el = codeBlockRef.current
     if (el) {
       setInstructionsOverflow(el.scrollHeight > el.clientHeight)
     }
-  }, [instructions])
+  }, [instructions, instructionsExpanded])
 
   const toggleRunSelection = (runId: string) => {
     setSelectedRunIds((current) => {
@@ -550,6 +555,7 @@ export function BenchmarkDetailsPage() {
           <section className="benchmark-details-section benchmark-details-instructions-section">
             <div className="benchmark-details-instructions-shell">
               <pre
+                id="benchmark-instructions-code"
                 ref={codeBlockRef}
                 className={`benchmark-details-code-block${instructionsExpanded ? ' expanded' : ''}`}
               >
@@ -568,9 +574,11 @@ export function BenchmarkDetailsPage() {
                 <button
                   type="button"
                   className="benchmark-details-instructions-toggle"
+                  aria-expanded={instructionsExpanded}
+                  aria-controls="benchmark-instructions-code"
                   onClick={() => setInstructionsExpanded((v) => !v)}
                 >
-                  {instructionsExpanded ? 'Show less' : 'Show more'}
+                  {instructionsExpanded ? 'Show less instructions' : 'Show more instructions'}
                 </button>
               )}
             </div>


### PR DESCRIPTION
## Summary

Closes #65 - Benchmark instructions that are too long no longer dominate the page.

### Changes
- **Reduced max-height** from 360px to 220px so the code block takes up less vertical space
- **Show more/less toggle** - a button appears below the code block when content overflows, letting users expand to see the full instructions or collapse back down
- Overflow detection via useRef + useEffect comparing scrollHeight vs clientHeight
- Toggle only renders when content actually overflows (short instructions show no button)

### Files changed
- src/App.css - reduced max-height, added .expanded modifier and .benchmark-details-instructions-toggle styles
- src/features/benchmarks/BenchmarkDetailsPage.tsx - added expand/collapse state, ref, overflow detection, toggle button
