### PR TITLE
feat: resource usage time-series charts on run results page (#75)

### DIFF
--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -1,0 +1,97 @@
+# Issue #75 — Resource Usage Charts: Implementation Notes
+
+## Status: Implementation Complete, Awaiting Review
+
+All 6 todos are **done**. Lint + build pass. No tests to run (repo has none yet).
+
+---
+
+## What was done
+
+### New file: `src/features/benchmarks/resourceCharting.ts`
+All types and data-processing functions for resource charts:
+- **Types**: `ResourceMetricKey`, `ResourceChartPoint`, `MultiSeriesResourcePoint`
+- **Single-entity** (machine charts): `normalizeResourceDataPoints()`, `applyResourceSlidingAverage()`, `resolveResourceYAxisDomain()`
+- **Multi-entity** (container charts): `mergeResourceSeries()`, `getMultiSeriesDataKeys()`, `applyMultiSeriesSlidingAverage()`, `resolveMultiSeriesYAxisDomain()`
+- **Helper**: `computeDomain()` shared by both domain resolvers
+
+### Modified: `src/features/benchmarks/BenchmarkRunResultsPage.tsx`
+- Added `ResourceChart` component (reusable Recharts `LineChart` wrapper for resource data)
+- Added `RESOURCE_SERIES_COLORS` palette and `ResourceLineConfig` interface
+- Added `cpuTooltipFormatter` and `byteTooltipFormatter` (Recharts tooltip formatters)
+- Added state: `resourceAxisScaleMode`, `resourceChartRenderMode`, `resourceSmoothingLevel`, `selectedServiceKeysByHost`
+- Added `useEffect` to initialize per-host service selection (all selected by default)
+- Added `processedHosts` useMemo — normalizes, smooths, merges chart data per host
+- Added handlers: `handleToggleService`, `handleSelectAllServices`, `handleSelectNoServices`
+- **Replaced** the old plain-text "Host resources" `<ul>` with interactive foldable `<details>` cards
+
+### Modified: `src/App.css`
+- Replaced `.run-results-host-list` styles with new classes:
+  - `.run-results-host-card` / `-summary` / `-name` / `-stats`
+  - `.run-results-host-machine-section` / `.run-results-host-container-section`
+  - `.run-results-resource-grid` (2-col → 1-col responsive)
+  - `.run-results-resource-chart-wrap` / `-title`
+  - `.run-results-service-selector` / `.run-results-service-pill` / `.is-selected`
+
+---
+
+## Architecture & Key Decisions
+
+### Layout
+Each host gets a foldable `<details>` card:
+- **Summary row**: host name + derived CPU avg, memory avg, net totals
+- **Machine section**: 4 single-line charts (CPU%, Memory, Network I/O, Block I/O)
+- **Container section**: service selector pills + 4 multi-line charts (one line per selected service)
+
+### Data flow
+```
+rawData.timeSeries.hosts[].dataPoints → normalizeResourceDataPoints → applyResourceSlidingAverage → machinePoints
+rawData.timeSeries.hosts[].services[].dataPoints → mergeResourceSeries → applyMultiSeriesSlidingAverage → container chart data
+```
+
+### Shared controls
+One set of controls (axis scale mode, render mode, smoothing slider) governs ALL resource charts across ALL host cards on the page.
+
+### Multi-series data key convention
+Container chart dataKeys use `${serviceKey}_${metricKey}` (e.g., `nginx.1_cpuPercentage`).
+
+### I/O chart conventions
+- **Solid line** for "in" (read/receive), **dashed line** (`strokeDasharray: '5 3'`) for "out" (write/send)
+- Same color per service entity
+
+### Memory limit
+When `memoryLimitBytes > 0`, a dashed reference line is shown on machine Memory charts.
+
+### Network/block bytes
+Values are **delta per sample interval** (not cumulative). No rate conversion is done.
+
+---
+
+## What's Next (Issue #76)
+
+Issue #76 covers **resource usage comparison across runs** — same charts but on the comparison page (`BenchmarkRunComparisonPage`). That work would:
+1. Create comparison-specific resource data processing (merge across runs)
+2. Add resource charts to the comparison page following the same `ResourceChart` component
+3. Allow selecting which runs to compare resource metrics for
+
+---
+
+## Validation Commands
+```bash
+npm run lint     # ESLint
+npm run build    # tsc -b && vite build
+npm run test     # vitest (currently no test files)
+```
+
+---
+
+## Relevant Files
+| File | Role |
+|------|------|
+| `src/features/benchmarks/resourceCharting.ts` | Data processing types & functions |
+| `src/features/benchmarks/BenchmarkRunResultsPage.tsx` | Page component with charts |
+| `src/App.css` | Styling |
+| `src/features/benchmarks/charting.ts` | Reference: K6 chart patterns (similar structure) |
+| `src/features/benchmarks/comparisonCharting.ts` | Reference: multi-entity merge pattern |
+| `src/features/benchmarks/service.ts` | API calls (`getBenchmarkRunRaw`) |
+| `openapi.yaml` | API schema for resource DTOs |

--- a/src/App.css
+++ b/src/App.css
@@ -1694,6 +1694,32 @@
   border-bottom: 0;
 }
 
+.run-results-host-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.run-results-host-list li {
+  border: 1px solid #d6e2f1;
+  border-radius: 10px;
+  background: #f8fbff;
+  padding: 0.65rem 0.75rem;
+}
+
+.run-results-host-list h3,
+.run-results-host-list h4 {
+  margin: 0 0 0.35rem;
+  color: #17324a;
+}
+
+.run-results-host-list p {
+  margin: 0.2rem 0;
+  color: #2f475f;
+}
+
 .run-results-host-card {
   border: 1px solid #d6e2f1;
   border-radius: 10px;

--- a/src/App.css
+++ b/src/App.css
@@ -1694,29 +1694,87 @@
   border-bottom: 0;
 }
 
-.run-results-host-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 0.55rem;
-}
-
-.run-results-host-list li {
+.run-results-host-card {
   border: 1px solid #d6e2f1;
   border-radius: 10px;
   background: #f8fbff;
-  padding: 0.65rem 0.75rem;
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 0.55rem;
 }
 
-.run-results-host-list h3 {
-  margin: 0 0 0.35rem;
+.run-results-host-card-summary {
+  cursor: pointer;
+  font-weight: 600;
   color: #17324a;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.5rem;
 }
 
-.run-results-host-list p {
-  margin: 0.2rem 0;
+.run-results-host-card-name {
+  font-size: 1rem;
+}
+
+.run-results-host-card-stats {
+  font-weight: 400;
+  font-size: 0.85rem;
   color: #2f475f;
+}
+
+.run-results-host-machine-section,
+.run-results-host-container-section {
+  padding-top: 0.75rem;
+  margin-top: 0.5rem;
+  border-top: 1px solid #e5eaf3;
+}
+
+.run-results-host-machine-section h4,
+.run-results-host-container-section h4 {
+  margin: 0 0 0.5rem;
+  color: #17324a;
+  font-size: 0.95rem;
+}
+
+.run-results-resource-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.75rem;
+}
+
+.run-results-resource-chart-wrap {
+  min-height: 230px;
+}
+
+.run-results-resource-chart-title {
+  margin: 0 0 0.25rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #2f475f;
+}
+
+.run-results-service-selector {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-bottom: 0.75rem;
+}
+
+.run-results-service-pill {
+  font-size: 0.82rem;
+  padding: 0.25rem 0.55rem;
+  border-radius: 6px;
+  border: 1px solid #d6e2f1;
+  background: #fff;
+  color: #2f475f;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.run-results-service-pill.is-selected {
+  background: #2563eb;
+  color: #fff;
+  border-color: #2563eb;
 }
 
 .run-results-raw-sections {
@@ -1767,6 +1825,10 @@
 
   .run-results-chart-container {
     height: 320px;
+  }
+
+  .run-results-resource-grid {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/src/features/benchmarks/BenchmarkRunResultsPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunResultsPage.tsx
@@ -284,6 +284,7 @@ function ResourceChart({
   yAxisFormatter,
   tooltipFormatter,
   showPointsOnly,
+  xAxisDomain,
 }: {
   title: string
   data: object[]
@@ -295,7 +296,8 @@ function ResourceChart({
     name: number | string | undefined,
   ) => [string, string]
   showPointsOnly: boolean
-}) {
+  xAxisDomain?: [number, number]
+}){
   if (data.length === 0) {
     return (
       <div className="run-results-resource-chart-wrap">
@@ -317,7 +319,7 @@ function ResourceChart({
           <XAxis
             dataKey="timestampMs"
             type="number"
-            domain={['dataMin', 'dataMax']}
+            domain={xAxisDomain ?? ['dataMin', 'dataMax']}
             minTickGap={42}
             tickFormatter={formatChartTickLabel}
           />
@@ -538,6 +540,14 @@ export function BenchmarkRunResultsPage() {
   const isZoomed =
     k6ChartPoints.length > 1 &&
     (brushStartIndex > 0 || brushEndIndex < k6ChartPoints.length - 1)
+
+  const brushTimeRange = useMemo<[number, number] | null>(() => {
+    if (k6ChartPoints.length === 0) return null
+    const startMs = k6ChartPoints[brushStartIndex]?.timestampMs
+    const endMs = k6ChartPoints[brushEndIndex]?.timestampMs
+    if (startMs == null || endMs == null) return null
+    return [startMs, endMs]
+  }, [brushStartIndex, brushEndIndex, k6ChartPoints])
 
   const handleBrushChange = (nextRange: BrushChangeEvent) => {
     if (k6ChartPoints.length === 0) {
@@ -1247,6 +1257,7 @@ export function BenchmarkRunResultsPage() {
                           yAxisFormatter={(v) => `${Math.round(v)}%`}
                           tooltipFormatter={cpuTooltipFormatter}
                           showPointsOnly={resourceShowPointsOnly}
+                          xAxisDomain={brushTimeRange ?? undefined}
                         />
                         <ResourceChart
                           title="Memory"
@@ -1256,6 +1267,7 @@ export function BenchmarkRunResultsPage() {
                           yAxisFormatter={(v) => formatBytes(v)}
                           tooltipFormatter={byteTooltipFormatter}
                           showPointsOnly={resourceShowPointsOnly}
+                          xAxisDomain={brushTimeRange ?? undefined}
                         />
                         <ResourceChart
                           title="Network I/O"
@@ -1268,6 +1280,7 @@ export function BenchmarkRunResultsPage() {
                           yAxisFormatter={(v) => formatBytes(v)}
                           tooltipFormatter={byteTooltipFormatter}
                           showPointsOnly={resourceShowPointsOnly}
+                          xAxisDomain={brushTimeRange ?? undefined}
                         />
                         <ResourceChart
                           title="Block I/O"
@@ -1280,6 +1293,7 @@ export function BenchmarkRunResultsPage() {
                           yAxisFormatter={(v) => formatBytes(v)}
                           tooltipFormatter={byteTooltipFormatter}
                           showPointsOnly={resourceShowPointsOnly}
+                          xAxisDomain={brushTimeRange ?? undefined}
                         />
                       </div>
                     </div>
@@ -1337,6 +1351,7 @@ export function BenchmarkRunResultsPage() {
                                 yAxisFormatter={(v) => `${Math.round(v)}%`}
                                 tooltipFormatter={cpuTooltipFormatter}
                                 showPointsOnly={resourceShowPointsOnly}
+                                xAxisDomain={brushTimeRange ?? undefined}
                               />
                               <ResourceChart
                                 title="Memory"
@@ -1346,6 +1361,7 @@ export function BenchmarkRunResultsPage() {
                                 yAxisFormatter={(v) => formatBytes(v)}
                                 tooltipFormatter={byteTooltipFormatter}
                                 showPointsOnly={resourceShowPointsOnly}
+                                xAxisDomain={brushTimeRange ?? undefined}
                               />
                               <ResourceChart
                                 title="Network I/O"
@@ -1355,6 +1371,7 @@ export function BenchmarkRunResultsPage() {
                                 yAxisFormatter={(v) => formatBytes(v)}
                                 tooltipFormatter={byteTooltipFormatter}
                                 showPointsOnly={resourceShowPointsOnly}
+                                xAxisDomain={brushTimeRange ?? undefined}
                               />
                               <ResourceChart
                                 title="Block I/O"
@@ -1364,6 +1381,7 @@ export function BenchmarkRunResultsPage() {
                                 yAxisFormatter={(v) => formatBytes(v)}
                                 tooltipFormatter={byteTooltipFormatter}
                                 showPointsOnly={resourceShowPointsOnly}
+                                xAxisDomain={brushTimeRange ?? undefined}
                               />
                             </div>
                           )}

--- a/src/features/benchmarks/BenchmarkRunResultsPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunResultsPage.tsx
@@ -20,11 +20,22 @@ import {
   applyK6SlidingAverage,
   K6_MS_METRICS,
   K6_VUS_METRICS,
+  type AxisDomain,
   type AxisScaleMode,
   type K6MetricKey,
   normalizeK6ChartPoints,
   resolveYAxisDomain,
 } from './charting'
+import {
+  applyMultiSeriesSlidingAverage,
+  applyResourceSlidingAverage,
+  getMultiSeriesDataKeys,
+  mergeResourceSeries,
+  normalizeResourceDataPoints,
+  resolveMultiSeriesYAxisDomain,
+  resolveResourceYAxisDomain,
+  type ResourceMetricKey,
+} from './resourceCharting'
 import {
   BenchmarkRunDetailsError,
   BenchmarkRunRawError,
@@ -228,6 +239,123 @@ function toK6MetricKey(value: unknown): K6MetricKey | null {
   return null
 }
 
+const RESOURCE_SERIES_COLORS = [
+  '#2563eb',
+  '#f97316',
+  '#16a34a',
+  '#dc2626',
+  '#8b5cf6',
+  '#06b6d4',
+  '#d97706',
+  '#ec4899',
+]
+
+interface ResourceLineConfig {
+  dataKey: string
+  name: string
+  color: string
+  strokeDasharray?: string
+}
+
+function makeResourceTooltipFormatter(isByteMetric: boolean) {
+  return (
+    value: number | string | ReadonlyArray<number | string> | null | undefined,
+    name: number | string | undefined,
+  ): [string, string] => {
+    const label = typeof name === 'undefined' ? 'Value' : String(name)
+    const normalizedValue = Array.isArray(value) ? value[0] : value
+    if (typeof normalizedValue !== 'number' || Number.isNaN(normalizedValue)) {
+      return ['n/a', label]
+    }
+    return isByteMetric
+      ? [formatBytes(normalizedValue), label]
+      : [`${normalizedValue.toFixed(1)}%`, label]
+  }
+}
+
+const cpuTooltipFormatter = makeResourceTooltipFormatter(false)
+const byteTooltipFormatter = makeResourceTooltipFormatter(true)
+
+function ResourceChart({
+  title,
+  data,
+  lines,
+  yAxisDomain,
+  yAxisFormatter,
+  tooltipFormatter,
+  showPointsOnly,
+}: {
+  title: string
+  data: object[]
+  lines: ResourceLineConfig[]
+  yAxisDomain: AxisDomain
+  yAxisFormatter: (value: number) => string
+  tooltipFormatter: (
+    value: number | string | ReadonlyArray<number | string> | null | undefined,
+    name: number | string | undefined,
+  ) => [string, string]
+  showPointsOnly: boolean
+}) {
+  if (data.length === 0) {
+    return (
+      <div className="run-results-resource-chart-wrap">
+        <h4 className="run-results-resource-chart-title">{title}</h4>
+        <p className="run-results-placeholder">No data</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="run-results-resource-chart-wrap">
+      <h4 className="run-results-resource-chart-title">{title}</h4>
+      <ResponsiveContainer width="100%" height={200}>
+        <LineChart
+          data={data}
+          margin={{ top: 4, right: 8, left: 0, bottom: 4 }}
+        >
+          <CartesianGrid stroke="#d9e2ef" strokeDasharray="3 3" />
+          <XAxis
+            dataKey="timestampMs"
+            type="number"
+            domain={['dataMin', 'dataMax']}
+            minTickGap={42}
+            tickFormatter={formatChartTickLabel}
+          />
+          <YAxis
+            domain={yAxisDomain}
+            tickFormatter={yAxisFormatter}
+            width={68}
+          />
+          <Tooltip
+            formatter={tooltipFormatter}
+            labelFormatter={formatChartTooltipLabel}
+            isAnimationActive={false}
+          />
+          <Legend />
+          {lines.map((line) => (
+            <Line
+              key={line.dataKey}
+              type="linear"
+              dataKey={line.dataKey}
+              name={line.name}
+              stroke={line.color}
+              strokeDasharray={line.strokeDasharray}
+              strokeWidth={showPointsOnly ? 0.0001 : 2}
+              dot={
+                showPointsOnly
+                  ? { r: 3, fill: line.color, stroke: line.color, strokeWidth: 1 }
+                  : false
+              }
+              activeDot={{ r: 4, fill: line.color, stroke: line.color }}
+              connectNulls
+            />
+          ))}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
 export function BenchmarkRunResultsPage() {
   const { environmentId = '', benchmarkId = '', runId = '' } = useParams<{
     environmentId: string
@@ -251,6 +379,12 @@ export function BenchmarkRunResultsPage() {
   const [smoothingLevel, setSmoothingLevel] = useState(0)
   const [visibleSeries, setVisibleSeries] = useState<SeriesVisibility>(DEFAULT_SERIES_VISIBILITY)
   const [brushRange, setBrushRange] = useState<BrushRange | null>(null)
+  const [resourceAxisScaleMode, setResourceAxisScaleMode] = useState<AxisScaleMode>('auto')
+  const [resourceChartRenderMode, setResourceChartRenderMode] = useState<ChartRenderMode>('line')
+  const [resourceSmoothingLevel, setResourceSmoothingLevel] = useState(0)
+  const [selectedServiceKeysByHost, setSelectedServiceKeysByHost] = useState<
+    Record<string, Set<string>>
+  >({})
 
   const environmentLabel = (environmentName ?? environmentId).trim() || 'n/a'
   const benchmarkLabel = (benchmarkName ?? benchmarkId).trim() || 'n/a'
@@ -464,6 +598,106 @@ export function BenchmarkRunResultsPage() {
         ? `/environments/${environmentId}/benchmarks/${benchmarkId}`
         : '/environments'
     navigate(fallbackPath)
+  }
+
+  useEffect(() => {
+    const hosts = rawData?.timeSeries?.hosts
+    if (!hosts) {
+      setSelectedServiceKeysByHost({})
+      return
+    }
+    const initial: Record<string, Set<string>> = {}
+    for (const host of hosts) {
+      const hostKey = host.hostId ?? host.hostName ?? ''
+      initial[hostKey] = new Set(
+        (host.services ?? []).map((s) => s.serviceId ?? s.serviceName ?? ''),
+      )
+    }
+    setSelectedServiceKeysByHost(initial)
+  }, [rawData])
+
+  const resourceSmoothingWindowSize =
+    resourceSmoothingLevel === 0 ? 1 : resourceSmoothingLevel + 1
+
+  const processedHosts = useMemo(() => {
+    const hosts = rawData?.timeSeries?.hosts ?? []
+    return hosts.map((host) => {
+      const hostKey = host.hostId ?? host.hostName ?? ''
+      const hostLabel = host.hostName ?? host.hostId ?? 'Host'
+
+      const rawMachinePoints = normalizeResourceDataPoints(host.dataPoints ?? [])
+      const machinePoints = applyResourceSlidingAverage(
+        rawMachinePoints,
+        resourceSmoothingWindowSize,
+      )
+      const hasMemoryLimit = machinePoints.some(
+        (p) => p.memoryLimitBytes != null && p.memoryLimitBytes > 0,
+      )
+
+      const allServices = (host.services ?? []).map((s) => ({
+        key: s.serviceId ?? s.serviceName ?? '',
+        label: s.serviceName ?? s.serviceId ?? 'Service',
+        dataPoints: s.dataPoints ?? [],
+      }))
+
+      const selectedKeys = selectedServiceKeysByHost[hostKey] ?? new Set<string>()
+      const selectedEntities = allServices.filter((s) => selectedKeys.has(s.key))
+
+      const buildChart = (metrics: ResourceMetricKey[]) => {
+        const data = mergeResourceSeries(selectedEntities, metrics)
+        const dataKeys = getMultiSeriesDataKeys(
+          selectedEntities.map((e) => e.key),
+          metrics,
+        )
+        return {
+          data: applyMultiSeriesSlidingAverage(data, dataKeys, resourceSmoothingWindowSize),
+          dataKeys,
+        }
+      }
+
+      const derivedSummary = (derivedData?.hosts ?? []).find(
+        (h) => (h.hostId ?? h.hostName) === hostKey,
+      )
+
+      return {
+        key: hostKey,
+        label: hostLabel,
+        derivedSummary,
+        machinePoints,
+        hasMemoryLimit,
+        allServices: allServices.map((s) => ({ key: s.key, label: s.label })),
+        containerCpu: buildChart(['cpuPercentage']),
+        containerMemory: buildChart(['memoryUsageBytes']),
+        containerNetwork: buildChart(['networkInBytes', 'networkOutBytes']),
+        containerBlock: buildChart(['blockInBytes', 'blockOutBytes']),
+      }
+    })
+  }, [rawData, derivedData, selectedServiceKeysByHost, resourceSmoothingWindowSize])
+
+  const handleToggleService = (hostKey: string, serviceKey: string) => {
+    setSelectedServiceKeysByHost((current) => {
+      const hostSet = new Set(current[hostKey] ?? [])
+      if (hostSet.has(serviceKey)) {
+        hostSet.delete(serviceKey)
+      } else {
+        hostSet.add(serviceKey)
+      }
+      return { ...current, [hostKey]: hostSet }
+    })
+  }
+
+  const handleSelectAllServices = (hostKey: string, allKeys: string[]) => {
+    setSelectedServiceKeysByHost((current) => ({
+      ...current,
+      [hostKey]: new Set(allKeys),
+    }))
+  }
+
+  const handleSelectNoServices = (hostKey: string) => {
+    setSelectedServiceKeysByHost((current) => ({
+      ...current,
+      [hostKey]: new Set<string>(),
+    }))
   }
 
   return (
@@ -818,27 +1052,328 @@ export function BenchmarkRunResultsPage() {
 
         <section className="run-results-section">
           <h2>Host resources</h2>
-          {hostMetrics.length === 0 ? (
+          {processedHosts.length === 0 ? (
             <p className="run-results-placeholder">
-              No host resource summaries are available for this run.
+              No host resource data is available for this run.
             </p>
           ) : (
-            <ul className="run-results-host-list">
-              {hostMetrics.map((host) => (
-                <li key={`${host.hostId ?? ''}|${host.hostName ?? ''}`}>
-                  <h3>{host.hostName ?? host.hostId ?? 'Host'}</h3>
-                  <p>
-                    CPU avg {formatMetric(host.resource?.cpu?.avg, '%')} | Memory avg{' '}
-                    {formatMetric(host.resource?.memory?.avg, '%')}
-                  </p>
-                  <p>
-                    Net in {formatBytes(host.resource?.networkInTotalBytes)} | Net out{' '}
-                    {formatBytes(host.resource?.networkOutTotalBytes)}
-                  </p>
-                  <p>Services: {host.services?.length ?? 0}</p>
-                </li>
-              ))}
-            </ul>
+            <>
+              <div className="run-results-chart-controls">
+                <div className="run-results-axis-mode-group" role="group" aria-label="Resource Y-axis scale">
+                  {AXIS_MODE_OPTIONS.map((option) => {
+                    const isSelected = resourceAxisScaleMode === option.value
+                    return (
+                      <button
+                        key={option.value}
+                        type="button"
+                        className={`shell-alert-dismiss run-results-axis-mode-button${
+                          isSelected ? ' is-selected' : ''
+                        }`}
+                        onClick={() => setResourceAxisScaleMode(option.value)}
+                        aria-pressed={isSelected}
+                        title={option.description}
+                      >
+                        {option.label}
+                      </button>
+                    )
+                  })}
+                </div>
+                <div className="run-results-axis-mode-group" role="group" aria-label="Resource render mode">
+                  {CHART_RENDER_MODE_OPTIONS.map((option) => {
+                    const isSelected = resourceChartRenderMode === option.value
+                    return (
+                      <button
+                        key={option.value}
+                        type="button"
+                        className={`shell-alert-dismiss run-results-axis-mode-button${
+                          isSelected ? ' is-selected' : ''
+                        }`}
+                        onClick={() => setResourceChartRenderMode(option.value)}
+                        aria-pressed={isSelected}
+                        title={option.description}
+                      >
+                        {option.label}
+                      </button>
+                    )
+                  })}
+                </div>
+                <div className="run-results-smoothing-slider-group">
+                  <label
+                    className="run-results-smoothing-slider-label"
+                    htmlFor="run-results-resource-smoothing-slider"
+                  >
+                    Sliding average: {resourceSmoothingLevel === 0 ? 'Raw' : resourceSmoothingLevel}
+                  </label>
+                  <input
+                    id="run-results-resource-smoothing-slider"
+                    className="run-results-smoothing-slider-input"
+                    type="range"
+                    min={0}
+                    max={9}
+                    step={1}
+                    value={resourceSmoothingLevel}
+                    onChange={(event) => {
+                      const nextLevel = Number(event.currentTarget.value)
+                      if (!Number.isNaN(nextLevel)) {
+                        setResourceSmoothingLevel(Math.min(Math.max(nextLevel, 0), 9))
+                      }
+                    }}
+                    aria-label="Resource sliding average level from 0 to 9"
+                  />
+                  <div className="run-results-smoothing-slider-marks" aria-hidden="true">
+                    <span>Raw</span>
+                    <span>5</span>
+                    <span>9</span>
+                  </div>
+                </div>
+              </div>
+
+              {processedHosts.map((host) => {
+                const selectedKeys = selectedServiceKeysByHost[host.key] ?? new Set<string>()
+                const resourceShowPointsOnly = resourceChartRenderMode === 'points'
+
+                const machineCpuDomain = resolveResourceYAxisDomain(
+                  host.machinePoints, ['cpuPercentage'], resourceAxisScaleMode,
+                )
+                const machineMemoryMetrics: ResourceMetricKey[] = host.hasMemoryLimit
+                  ? ['memoryUsageBytes', 'memoryLimitBytes']
+                  : ['memoryUsageBytes']
+                const machineMemoryDomain = resolveResourceYAxisDomain(
+                  host.machinePoints, machineMemoryMetrics, resourceAxisScaleMode,
+                )
+                const machineNetworkDomain = resolveResourceYAxisDomain(
+                  host.machinePoints, ['networkInBytes', 'networkOutBytes'], resourceAxisScaleMode,
+                )
+                const machineBlockDomain = resolveResourceYAxisDomain(
+                  host.machinePoints, ['blockInBytes', 'blockOutBytes'], resourceAxisScaleMode,
+                )
+
+                const machineMemoryLines: ResourceLineConfig[] = [
+                  { dataKey: 'memoryUsageBytes', name: 'Usage', color: '#8b5cf6' },
+                ]
+                if (host.hasMemoryLimit) {
+                  machineMemoryLines.push({
+                    dataKey: 'memoryLimitBytes',
+                    name: 'Limit',
+                    color: '#94a3b8',
+                    strokeDasharray: '5 3',
+                  })
+                }
+
+                const selectedServiceEntities = host.allServices.filter((s) =>
+                  selectedKeys.has(s.key),
+                )
+                const containerCpuLines: ResourceLineConfig[] = selectedServiceEntities.map(
+                  (s, i) => ({
+                    dataKey: `${s.key}_cpuPercentage`,
+                    name: s.label,
+                    color: RESOURCE_SERIES_COLORS[i % RESOURCE_SERIES_COLORS.length],
+                  }),
+                )
+                const containerMemoryLines: ResourceLineConfig[] = selectedServiceEntities.map(
+                  (s, i) => ({
+                    dataKey: `${s.key}_memoryUsageBytes`,
+                    name: s.label,
+                    color: RESOURCE_SERIES_COLORS[i % RESOURCE_SERIES_COLORS.length],
+                  }),
+                )
+                const containerNetworkLines: ResourceLineConfig[] =
+                  selectedServiceEntities.flatMap((s, i) => {
+                    const color = RESOURCE_SERIES_COLORS[i % RESOURCE_SERIES_COLORS.length]
+                    return [
+                      { dataKey: `${s.key}_networkInBytes`, name: `${s.label} (in)`, color },
+                      {
+                        dataKey: `${s.key}_networkOutBytes`,
+                        name: `${s.label} (out)`,
+                        color,
+                        strokeDasharray: '5 3',
+                      },
+                    ]
+                  })
+                const containerBlockLines: ResourceLineConfig[] =
+                  selectedServiceEntities.flatMap((s, i) => {
+                    const color = RESOURCE_SERIES_COLORS[i % RESOURCE_SERIES_COLORS.length]
+                    return [
+                      { dataKey: `${s.key}_blockInBytes`, name: `${s.label} (in)`, color },
+                      {
+                        dataKey: `${s.key}_blockOutBytes`,
+                        name: `${s.label} (out)`,
+                        color,
+                        strokeDasharray: '5 3',
+                      },
+                    ]
+                  })
+
+                const containerCpuDomain = resolveMultiSeriesYAxisDomain(
+                  host.containerCpu.data, host.containerCpu.dataKeys, resourceAxisScaleMode,
+                )
+                const containerMemoryDomain = resolveMultiSeriesYAxisDomain(
+                  host.containerMemory.data, host.containerMemory.dataKeys, resourceAxisScaleMode,
+                )
+                const containerNetworkDomain = resolveMultiSeriesYAxisDomain(
+                  host.containerNetwork.data, host.containerNetwork.dataKeys, resourceAxisScaleMode,
+                )
+                const containerBlockDomain = resolveMultiSeriesYAxisDomain(
+                  host.containerBlock.data, host.containerBlock.dataKeys, resourceAxisScaleMode,
+                )
+
+                const derivedCpu = host.derivedSummary?.resource?.cpu
+                const derivedMemory = host.derivedSummary?.resource?.memory
+
+                return (
+                  <details key={host.key} className="run-results-host-card" open>
+                    <summary className="run-results-host-card-summary">
+                      <span className="run-results-host-card-name">{host.label}</span>
+                      <span className="run-results-host-card-stats">
+                        CPU avg {formatMetric(derivedCpu?.avg, '%')} | Mem avg{' '}
+                        {formatMetric(derivedMemory?.avg, '%')}
+                        {' | '}
+                        Net in {formatBytes(host.derivedSummary?.resource?.networkInTotalBytes)}{' '}
+                        | Net out{' '}
+                        {formatBytes(host.derivedSummary?.resource?.networkOutTotalBytes)}
+                      </span>
+                    </summary>
+
+                    <div className="run-results-host-machine-section">
+                      <h4>Machine</h4>
+                      <div className="run-results-resource-grid">
+                        <ResourceChart
+                          title="CPU %"
+                          data={host.machinePoints}
+                          lines={[
+                            { dataKey: 'cpuPercentage', name: 'CPU %', color: '#2563eb' },
+                          ]}
+                          yAxisDomain={machineCpuDomain}
+                          yAxisFormatter={(v) => `${Math.round(v)}%`}
+                          tooltipFormatter={cpuTooltipFormatter}
+                          showPointsOnly={resourceShowPointsOnly}
+                        />
+                        <ResourceChart
+                          title="Memory"
+                          data={host.machinePoints}
+                          lines={machineMemoryLines}
+                          yAxisDomain={machineMemoryDomain}
+                          yAxisFormatter={(v) => formatBytes(v)}
+                          tooltipFormatter={byteTooltipFormatter}
+                          showPointsOnly={resourceShowPointsOnly}
+                        />
+                        <ResourceChart
+                          title="Network I/O"
+                          data={host.machinePoints}
+                          lines={[
+                            { dataKey: 'networkInBytes', name: 'In', color: '#16a34a' },
+                            { dataKey: 'networkOutBytes', name: 'Out', color: '#f97316' },
+                          ]}
+                          yAxisDomain={machineNetworkDomain}
+                          yAxisFormatter={(v) => formatBytes(v)}
+                          tooltipFormatter={byteTooltipFormatter}
+                          showPointsOnly={resourceShowPointsOnly}
+                        />
+                        <ResourceChart
+                          title="Block I/O"
+                          data={host.machinePoints}
+                          lines={[
+                            { dataKey: 'blockInBytes', name: 'In', color: '#06b6d4' },
+                            { dataKey: 'blockOutBytes', name: 'Out', color: '#d97706' },
+                          ]}
+                          yAxisDomain={machineBlockDomain}
+                          yAxisFormatter={(v) => formatBytes(v)}
+                          tooltipFormatter={byteTooltipFormatter}
+                          showPointsOnly={resourceShowPointsOnly}
+                        />
+                      </div>
+                    </div>
+
+                    <div className="run-results-host-container-section">
+                      <h4>Containers</h4>
+                      {host.allServices.length === 0 ? (
+                        <p className="run-results-placeholder">
+                          No containers recorded for this host.
+                        </p>
+                      ) : (
+                        <>
+                          <div className="run-results-service-selector">
+                            <button
+                              type="button"
+                              className="shell-alert-dismiss run-results-service-pill"
+                              onClick={() =>
+                                handleSelectAllServices(
+                                  host.key,
+                                  host.allServices.map((s) => s.key),
+                                )
+                              }
+                            >
+                              Select all
+                            </button>
+                            <button
+                              type="button"
+                              className="shell-alert-dismiss run-results-service-pill"
+                              onClick={() => handleSelectNoServices(host.key)}
+                            >
+                              Select none
+                            </button>
+                            {host.allServices.map((service) => (
+                              <button
+                                key={service.key}
+                                type="button"
+                                className={`shell-alert-dismiss run-results-service-pill${
+                                  selectedKeys.has(service.key) ? ' is-selected' : ''
+                                }`}
+                                onClick={() => handleToggleService(host.key, service.key)}
+                              >
+                                {service.label}
+                              </button>
+                            ))}
+                          </div>
+                          {selectedKeys.size === 0 ? (
+                            <p className="run-results-placeholder">No services selected.</p>
+                          ) : (
+                            <div className="run-results-resource-grid">
+                              <ResourceChart
+                                title="CPU %"
+                                data={host.containerCpu.data}
+                                lines={containerCpuLines}
+                                yAxisDomain={containerCpuDomain}
+                                yAxisFormatter={(v) => `${Math.round(v)}%`}
+                                tooltipFormatter={cpuTooltipFormatter}
+                                showPointsOnly={resourceShowPointsOnly}
+                              />
+                              <ResourceChart
+                                title="Memory"
+                                data={host.containerMemory.data}
+                                lines={containerMemoryLines}
+                                yAxisDomain={containerMemoryDomain}
+                                yAxisFormatter={(v) => formatBytes(v)}
+                                tooltipFormatter={byteTooltipFormatter}
+                                showPointsOnly={resourceShowPointsOnly}
+                              />
+                              <ResourceChart
+                                title="Network I/O"
+                                data={host.containerNetwork.data}
+                                lines={containerNetworkLines}
+                                yAxisDomain={containerNetworkDomain}
+                                yAxisFormatter={(v) => formatBytes(v)}
+                                tooltipFormatter={byteTooltipFormatter}
+                                showPointsOnly={resourceShowPointsOnly}
+                              />
+                              <ResourceChart
+                                title="Block I/O"
+                                data={host.containerBlock.data}
+                                lines={containerBlockLines}
+                                yAxisDomain={containerBlockDomain}
+                                yAxisFormatter={(v) => formatBytes(v)}
+                                tooltipFormatter={byteTooltipFormatter}
+                                showPointsOnly={resourceShowPointsOnly}
+                              />
+                            </div>
+                          )}
+                        </>
+                      )}
+                    </div>
+                  </details>
+                )
+              })}
+            </>
           )}
         </section>
 

--- a/src/features/benchmarks/BenchmarkRunResultsPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunResultsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import {
   Brush,
@@ -296,6 +296,23 @@ function ResourceChart({
   ) => [string, string]
   showPointsOnly: boolean
 }){
+  const [hiddenLines, setHiddenLines] = useState<Set<string>>(new Set())
+
+  const handleLegendClick = useCallback((entry: unknown) => {
+    if (!entry || typeof entry !== 'object' || !('dataKey' in entry)) return
+    const dataKey = (entry as { dataKey?: string }).dataKey
+    if (typeof dataKey !== 'string') return
+    setHiddenLines((current) => {
+      const next = new Set(current)
+      if (next.has(dataKey)) {
+        next.delete(dataKey)
+      } else {
+        next.add(dataKey)
+      }
+      return next
+    })
+  }, [])
+
   if (data.length === 0) {
     return (
       <div className="run-results-resource-chart-wrap">
@@ -331,7 +348,7 @@ function ResourceChart({
             labelFormatter={formatChartTooltipLabel}
             isAnimationActive={false}
           />
-          <Legend />
+          <Legend onClick={handleLegendClick} />
           {lines.map((line) => (
             <Line
               key={line.dataKey}
@@ -348,6 +365,7 @@ function ResourceChart({
               }
               activeDot={{ r: 4, fill: line.color, stroke: line.color }}
               connectNulls
+              hide={hiddenLines.has(line.dataKey)}
             />
           ))}
         </LineChart>
@@ -615,10 +633,11 @@ export function BenchmarkRunResultsPage() {
       return
     }
     const initial: Record<string, Set<string>> = {}
-    for (const host of hosts) {
-      const hostKey = host.hostId ?? host.hostName ?? ''
+    for (let i = 0; i < hosts.length; i++) {
+      const host = hosts[i]
+      const hostKey = host.hostId ?? host.hostName ?? `host-${i}`
       initial[hostKey] = new Set(
-        (host.services ?? []).map((s) => s.serviceId ?? s.serviceName ?? ''),
+        (host.services ?? []).map((s, j) => s.serviceId ?? s.serviceName ?? `service-${j}`),
       )
     }
     setSelectedServiceKeysByHost(initial)
@@ -629,8 +648,8 @@ export function BenchmarkRunResultsPage() {
 
   const processedHosts = useMemo(() => {
     const hosts = rawData?.timeSeries?.hosts ?? []
-    return hosts.map((host) => {
-      const hostKey = host.hostId ?? host.hostName ?? ''
+    return hosts.map((host, hostIndex) => {
+      const hostKey = host.hostId ?? host.hostName ?? `host-${hostIndex}`
       const hostLabel = host.hostName ?? host.hostId ?? 'Host'
 
       const rawMachinePoints = normalizeResourceDataPoints(host.dataPoints ?? [])
@@ -642,8 +661,42 @@ export function BenchmarkRunResultsPage() {
         (p) => p.memoryLimitBytes != null && p.memoryLimitBytes > 0,
       )
 
-      const allServices = (host.services ?? []).map((s) => ({
-        key: s.serviceId ?? s.serviceName ?? '',
+      const visibleMachinePoints = brushTimeRange
+        ? machinePoints.filter(
+            (p) => p.timestampMs >= brushTimeRange[0] && p.timestampMs <= brushTimeRange[1],
+          )
+        : machinePoints
+
+      const machineCpuDomain = resolveResourceYAxisDomain(
+        visibleMachinePoints, ['cpuPercentage'], resourceAxisScaleMode,
+      )
+      const machineMemoryMetrics: ResourceMetricKey[] = hasMemoryLimit
+        ? ['memoryUsageBytes', 'memoryLimitBytes']
+        : ['memoryUsageBytes']
+      const machineMemoryDomain = resolveResourceYAxisDomain(
+        visibleMachinePoints, machineMemoryMetrics, resourceAxisScaleMode,
+      )
+      const machineNetworkDomain = resolveResourceYAxisDomain(
+        visibleMachinePoints, ['networkInBytes', 'networkOutBytes'], resourceAxisScaleMode,
+      )
+      const machineBlockDomain = resolveResourceYAxisDomain(
+        visibleMachinePoints, ['blockInBytes', 'blockOutBytes'], resourceAxisScaleMode,
+      )
+
+      const machineMemoryLines: ResourceLineConfig[] = [
+        { dataKey: 'memoryUsageBytes', name: 'Usage', color: '#8b5cf6' },
+      ]
+      if (hasMemoryLimit) {
+        machineMemoryLines.push({
+          dataKey: 'memoryLimitBytes',
+          name: 'Limit',
+          color: '#94a3b8',
+          strokeDasharray: '5 3',
+        })
+      }
+
+      const allServices = (host.services ?? []).map((s, serviceIndex) => ({
+        key: s.serviceId ?? s.serviceName ?? `service-${serviceIndex}`,
         label: s.serviceName ?? s.serviceId ?? 'Service',
         dataPoints: s.dataPoints ?? [],
       }))
@@ -663,6 +716,81 @@ export function BenchmarkRunResultsPage() {
         }
       }
 
+      const containerCpu = buildChart(['cpuPercentage'])
+      const containerMemory = buildChart(['memoryUsageBytes'])
+      const containerNetwork = buildChart(['networkInBytes', 'networkOutBytes'])
+      const containerBlock = buildChart(['blockInBytes', 'blockOutBytes'])
+
+      const filterContainerData = <T extends { timestampMs: number | string }>(
+        points: T[],
+      ): T[] => {
+        if (!brushTimeRange) return points
+        return points.filter(
+          (p) =>
+            (p.timestampMs as number) >= brushTimeRange[0] &&
+            (p.timestampMs as number) <= brushTimeRange[1],
+        )
+      }
+
+      const visibleContainerCpuData = filterContainerData(containerCpu.data)
+      const visibleContainerMemoryData = filterContainerData(containerMemory.data)
+      const visibleContainerNetworkData = filterContainerData(containerNetwork.data)
+      const visibleContainerBlockData = filterContainerData(containerBlock.data)
+
+      const containerCpuDomain = resolveMultiSeriesYAxisDomain(
+        visibleContainerCpuData, containerCpu.dataKeys, resourceAxisScaleMode,
+      )
+      const containerMemoryDomain = resolveMultiSeriesYAxisDomain(
+        visibleContainerMemoryData, containerMemory.dataKeys, resourceAxisScaleMode,
+      )
+      const containerNetworkDomain = resolveMultiSeriesYAxisDomain(
+        visibleContainerNetworkData, containerNetwork.dataKeys, resourceAxisScaleMode,
+      )
+      const containerBlockDomain = resolveMultiSeriesYAxisDomain(
+        visibleContainerBlockData, containerBlock.dataKeys, resourceAxisScaleMode,
+      )
+
+      const containerCpuLines: ResourceLineConfig[] = selectedEntities.map(
+        (s, i) => ({
+          dataKey: `${s.key}_cpuPercentage`,
+          name: s.label,
+          color: RESOURCE_SERIES_COLORS[i % RESOURCE_SERIES_COLORS.length],
+        }),
+      )
+      const containerMemoryLines: ResourceLineConfig[] = selectedEntities.map(
+        (s, i) => ({
+          dataKey: `${s.key}_memoryUsageBytes`,
+          name: s.label,
+          color: RESOURCE_SERIES_COLORS[i % RESOURCE_SERIES_COLORS.length],
+        }),
+      )
+      const containerNetworkLines: ResourceLineConfig[] =
+        selectedEntities.flatMap((s, i) => {
+          const color = RESOURCE_SERIES_COLORS[i % RESOURCE_SERIES_COLORS.length]
+          return [
+            { dataKey: `${s.key}_networkInBytes`, name: `${s.label} (in)`, color },
+            {
+              dataKey: `${s.key}_networkOutBytes`,
+              name: `${s.label} (out)`,
+              color,
+              strokeDasharray: '5 3',
+            },
+          ]
+        })
+      const containerBlockLines: ResourceLineConfig[] =
+        selectedEntities.flatMap((s, i) => {
+          const color = RESOURCE_SERIES_COLORS[i % RESOURCE_SERIES_COLORS.length]
+          return [
+            { dataKey: `${s.key}_blockInBytes`, name: `${s.label} (in)`, color },
+            {
+              dataKey: `${s.key}_blockOutBytes`,
+              name: `${s.label} (out)`,
+              color,
+              strokeDasharray: '5 3',
+            },
+          ]
+        })
+
       const derivedSummary = (derivedData?.hosts ?? []).find(
         (h) => (h.hostId ?? h.hostName) === hostKey,
       )
@@ -671,16 +799,29 @@ export function BenchmarkRunResultsPage() {
         key: hostKey,
         label: hostLabel,
         derivedSummary,
-        machinePoints,
+        visibleMachinePoints,
         hasMemoryLimit,
         allServices: allServices.map((s) => ({ key: s.key, label: s.label })),
-        containerCpu: buildChart(['cpuPercentage']),
-        containerMemory: buildChart(['memoryUsageBytes']),
-        containerNetwork: buildChart(['networkInBytes', 'networkOutBytes']),
-        containerBlock: buildChart(['blockInBytes', 'blockOutBytes']),
+        machineCpuDomain,
+        machineMemoryDomain,
+        machineMemoryLines,
+        machineNetworkDomain,
+        machineBlockDomain,
+        visibleContainerCpuData,
+        visibleContainerMemoryData,
+        visibleContainerNetworkData,
+        visibleContainerBlockData,
+        containerCpuDomain,
+        containerCpuLines,
+        containerMemoryDomain,
+        containerMemoryLines,
+        containerNetworkDomain,
+        containerNetworkLines,
+        containerBlockDomain,
+        containerBlockLines,
       }
     })
-  }, [rawData, derivedData, selectedServiceKeysByHost, resourceSmoothingWindowSize])
+  }, [rawData, derivedData, selectedServiceKeysByHost, resourceSmoothingWindowSize, brushTimeRange, resourceAxisScaleMode])
 
   const handleToggleService = (hostKey: string, serviceKey: string) => {
     setSelectedServiceKeysByHost((current) => {
@@ -1140,113 +1281,6 @@ export function BenchmarkRunResultsPage() {
                 const selectedKeys = selectedServiceKeysByHost[host.key] ?? new Set<string>()
                 const resourceShowPointsOnly = resourceChartRenderMode === 'points'
 
-                const visibleMachinePoints = brushTimeRange
-                  ? host.machinePoints.filter(
-                      (p) => p.timestampMs >= brushTimeRange[0] && p.timestampMs <= brushTimeRange[1],
-                    )
-                  : host.machinePoints
-
-                const machineCpuDomain = resolveResourceYAxisDomain(
-                  visibleMachinePoints, ['cpuPercentage'], resourceAxisScaleMode,
-                )
-                const machineMemoryMetrics: ResourceMetricKey[] = host.hasMemoryLimit
-                  ? ['memoryUsageBytes', 'memoryLimitBytes']
-                  : ['memoryUsageBytes']
-                const machineMemoryDomain = resolveResourceYAxisDomain(
-                  visibleMachinePoints, machineMemoryMetrics, resourceAxisScaleMode,
-                )
-                const machineNetworkDomain = resolveResourceYAxisDomain(
-                  visibleMachinePoints, ['networkInBytes', 'networkOutBytes'], resourceAxisScaleMode,
-                )
-                const machineBlockDomain = resolveResourceYAxisDomain(
-                  visibleMachinePoints, ['blockInBytes', 'blockOutBytes'], resourceAxisScaleMode,
-                )
-
-                const machineMemoryLines: ResourceLineConfig[] = [
-                  { dataKey: 'memoryUsageBytes', name: 'Usage', color: '#8b5cf6' },
-                ]
-                if (host.hasMemoryLimit) {
-                  machineMemoryLines.push({
-                    dataKey: 'memoryLimitBytes',
-                    name: 'Limit',
-                    color: '#94a3b8',
-                    strokeDasharray: '5 3',
-                  })
-                }
-
-                const selectedServiceEntities = host.allServices.filter((s) =>
-                  selectedKeys.has(s.key),
-                )
-                const containerCpuLines: ResourceLineConfig[] = selectedServiceEntities.map(
-                  (s, i) => ({
-                    dataKey: `${s.key}_cpuPercentage`,
-                    name: s.label,
-                    color: RESOURCE_SERIES_COLORS[i % RESOURCE_SERIES_COLORS.length],
-                  }),
-                )
-                const containerMemoryLines: ResourceLineConfig[] = selectedServiceEntities.map(
-                  (s, i) => ({
-                    dataKey: `${s.key}_memoryUsageBytes`,
-                    name: s.label,
-                    color: RESOURCE_SERIES_COLORS[i % RESOURCE_SERIES_COLORS.length],
-                  }),
-                )
-                const containerNetworkLines: ResourceLineConfig[] =
-                  selectedServiceEntities.flatMap((s, i) => {
-                    const color = RESOURCE_SERIES_COLORS[i % RESOURCE_SERIES_COLORS.length]
-                    return [
-                      { dataKey: `${s.key}_networkInBytes`, name: `${s.label} (in)`, color },
-                      {
-                        dataKey: `${s.key}_networkOutBytes`,
-                        name: `${s.label} (out)`,
-                        color,
-                        strokeDasharray: '5 3',
-                      },
-                    ]
-                  })
-                const containerBlockLines: ResourceLineConfig[] =
-                  selectedServiceEntities.flatMap((s, i) => {
-                    const color = RESOURCE_SERIES_COLORS[i % RESOURCE_SERIES_COLORS.length]
-                    return [
-                      { dataKey: `${s.key}_blockInBytes`, name: `${s.label} (in)`, color },
-                      {
-                        dataKey: `${s.key}_blockOutBytes`,
-                        name: `${s.label} (out)`,
-                        color,
-                        strokeDasharray: '5 3',
-                      },
-                    ]
-                  })
-
-                const filterContainerData = <T extends { timestampMs: number | string }>(
-                  points: T[],
-                ): T[] => {
-                  if (!brushTimeRange) return points
-                  return points.filter(
-                    (p) =>
-                      (p.timestampMs as number) >= brushTimeRange[0] &&
-                      (p.timestampMs as number) <= brushTimeRange[1],
-                  )
-                }
-
-                const visibleContainerCpuData = filterContainerData(host.containerCpu.data)
-                const visibleContainerMemoryData = filterContainerData(host.containerMemory.data)
-                const visibleContainerNetworkData = filterContainerData(host.containerNetwork.data)
-                const visibleContainerBlockData = filterContainerData(host.containerBlock.data)
-
-                const containerCpuDomain = resolveMultiSeriesYAxisDomain(
-                  visibleContainerCpuData, host.containerCpu.dataKeys, resourceAxisScaleMode,
-                )
-                const containerMemoryDomain = resolveMultiSeriesYAxisDomain(
-                  visibleContainerMemoryData, host.containerMemory.dataKeys, resourceAxisScaleMode,
-                )
-                const containerNetworkDomain = resolveMultiSeriesYAxisDomain(
-                  visibleContainerNetworkData, host.containerNetwork.dataKeys, resourceAxisScaleMode,
-                )
-                const containerBlockDomain = resolveMultiSeriesYAxisDomain(
-                  visibleContainerBlockData, host.containerBlock.dataKeys, resourceAxisScaleMode,
-                )
-
                 const derivedCpu = host.derivedSummary?.resource?.cpu
                 const derivedMemory = host.derivedSummary?.resource?.memory
 
@@ -1269,44 +1303,44 @@ export function BenchmarkRunResultsPage() {
                       <div className="run-results-resource-grid">
                         <ResourceChart
                           title="CPU %"
-                          data={visibleMachinePoints}
+                          data={host.visibleMachinePoints}
                           lines={[
                             { dataKey: 'cpuPercentage', name: 'CPU %', color: '#2563eb' },
                           ]}
-                          yAxisDomain={machineCpuDomain}
+                          yAxisDomain={host.machineCpuDomain}
                           yAxisFormatter={(v) => `${Math.round(v)}%`}
                           tooltipFormatter={cpuTooltipFormatter}
                           showPointsOnly={resourceShowPointsOnly}
                         />
                         <ResourceChart
                           title="Memory"
-                          data={visibleMachinePoints}
-                          lines={machineMemoryLines}
-                          yAxisDomain={machineMemoryDomain}
+                          data={host.visibleMachinePoints}
+                          lines={host.machineMemoryLines}
+                          yAxisDomain={host.machineMemoryDomain}
                           yAxisFormatter={(v) => formatBytes(v)}
                           tooltipFormatter={byteTooltipFormatter}
                           showPointsOnly={resourceShowPointsOnly}
                         />
                         <ResourceChart
                           title="Network I/O"
-                          data={visibleMachinePoints}
+                          data={host.visibleMachinePoints}
                           lines={[
                             { dataKey: 'networkInBytes', name: 'In', color: '#16a34a' },
                             { dataKey: 'networkOutBytes', name: 'Out', color: '#f97316' },
                           ]}
-                          yAxisDomain={machineNetworkDomain}
+                          yAxisDomain={host.machineNetworkDomain}
                           yAxisFormatter={(v) => formatBytes(v)}
                           tooltipFormatter={byteTooltipFormatter}
                           showPointsOnly={resourceShowPointsOnly}
                         />
                         <ResourceChart
                           title="Block I/O"
-                          data={visibleMachinePoints}
+                          data={host.visibleMachinePoints}
                           lines={[
                             { dataKey: 'blockInBytes', name: 'In', color: '#06b6d4' },
                             { dataKey: 'blockOutBytes', name: 'Out', color: '#d97706' },
                           ]}
-                          yAxisDomain={machineBlockDomain}
+                          yAxisDomain={host.machineBlockDomain}
                           yAxisFormatter={(v) => formatBytes(v)}
                           tooltipFormatter={byteTooltipFormatter}
                           showPointsOnly={resourceShowPointsOnly}
@@ -1346,6 +1380,7 @@ export function BenchmarkRunResultsPage() {
                               <button
                                 key={service.key}
                                 type="button"
+                                aria-pressed={selectedKeys.has(service.key)}
                                 className={`shell-alert-dismiss run-results-service-pill${
                                   selectedKeys.has(service.key) ? ' is-selected' : ''
                                 }`}
@@ -1361,36 +1396,36 @@ export function BenchmarkRunResultsPage() {
                             <div className="run-results-resource-grid">
                               <ResourceChart
                                 title="CPU %"
-                                data={visibleContainerCpuData}
-                                lines={containerCpuLines}
-                                yAxisDomain={containerCpuDomain}
+                                data={host.visibleContainerCpuData}
+                                lines={host.containerCpuLines}
+                                yAxisDomain={host.containerCpuDomain}
                                 yAxisFormatter={(v) => `${Math.round(v)}%`}
                                 tooltipFormatter={cpuTooltipFormatter}
                                 showPointsOnly={resourceShowPointsOnly}
                               />
                               <ResourceChart
                                 title="Memory"
-                                data={visibleContainerMemoryData}
-                                lines={containerMemoryLines}
-                                yAxisDomain={containerMemoryDomain}
+                                data={host.visibleContainerMemoryData}
+                                lines={host.containerMemoryLines}
+                                yAxisDomain={host.containerMemoryDomain}
                                 yAxisFormatter={(v) => formatBytes(v)}
                                 tooltipFormatter={byteTooltipFormatter}
                                 showPointsOnly={resourceShowPointsOnly}
                               />
                               <ResourceChart
                                 title="Network I/O"
-                                data={visibleContainerNetworkData}
-                                lines={containerNetworkLines}
-                                yAxisDomain={containerNetworkDomain}
+                                data={host.visibleContainerNetworkData}
+                                lines={host.containerNetworkLines}
+                                yAxisDomain={host.containerNetworkDomain}
                                 yAxisFormatter={(v) => formatBytes(v)}
                                 tooltipFormatter={byteTooltipFormatter}
                                 showPointsOnly={resourceShowPointsOnly}
                               />
                               <ResourceChart
                                 title="Block I/O"
-                                data={visibleContainerBlockData}
-                                lines={containerBlockLines}
-                                yAxisDomain={containerBlockDomain}
+                                data={host.visibleContainerBlockData}
+                                lines={host.containerBlockLines}
+                                yAxisDomain={host.containerBlockDomain}
                                 yAxisFormatter={(v) => formatBytes(v)}
                                 tooltipFormatter={byteTooltipFormatter}
                                 showPointsOnly={resourceShowPointsOnly}

--- a/src/features/benchmarks/BenchmarkRunResultsPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunResultsPage.tsx
@@ -284,7 +284,6 @@ function ResourceChart({
   yAxisFormatter,
   tooltipFormatter,
   showPointsOnly,
-  xAxisDomain,
 }: {
   title: string
   data: object[]
@@ -296,7 +295,6 @@ function ResourceChart({
     name: number | string | undefined,
   ) => [string, string]
   showPointsOnly: boolean
-  xAxisDomain?: [number, number]
 }){
   if (data.length === 0) {
     return (
@@ -319,7 +317,7 @@ function ResourceChart({
           <XAxis
             dataKey="timestampMs"
             type="number"
-            domain={xAxisDomain ?? ['dataMin', 'dataMax']}
+            domain={['dataMin', 'dataMax']}
             minTickGap={42}
             tickFormatter={formatChartTickLabel}
           />
@@ -1142,20 +1140,26 @@ export function BenchmarkRunResultsPage() {
                 const selectedKeys = selectedServiceKeysByHost[host.key] ?? new Set<string>()
                 const resourceShowPointsOnly = resourceChartRenderMode === 'points'
 
+                const visibleMachinePoints = brushTimeRange
+                  ? host.machinePoints.filter(
+                      (p) => p.timestampMs >= brushTimeRange[0] && p.timestampMs <= brushTimeRange[1],
+                    )
+                  : host.machinePoints
+
                 const machineCpuDomain = resolveResourceYAxisDomain(
-                  host.machinePoints, ['cpuPercentage'], resourceAxisScaleMode,
+                  visibleMachinePoints, ['cpuPercentage'], resourceAxisScaleMode,
                 )
                 const machineMemoryMetrics: ResourceMetricKey[] = host.hasMemoryLimit
                   ? ['memoryUsageBytes', 'memoryLimitBytes']
                   : ['memoryUsageBytes']
                 const machineMemoryDomain = resolveResourceYAxisDomain(
-                  host.machinePoints, machineMemoryMetrics, resourceAxisScaleMode,
+                  visibleMachinePoints, machineMemoryMetrics, resourceAxisScaleMode,
                 )
                 const machineNetworkDomain = resolveResourceYAxisDomain(
-                  host.machinePoints, ['networkInBytes', 'networkOutBytes'], resourceAxisScaleMode,
+                  visibleMachinePoints, ['networkInBytes', 'networkOutBytes'], resourceAxisScaleMode,
                 )
                 const machineBlockDomain = resolveResourceYAxisDomain(
-                  host.machinePoints, ['blockInBytes', 'blockOutBytes'], resourceAxisScaleMode,
+                  visibleMachinePoints, ['blockInBytes', 'blockOutBytes'], resourceAxisScaleMode,
                 )
 
                 const machineMemoryLines: ResourceLineConfig[] = [
@@ -1214,17 +1218,33 @@ export function BenchmarkRunResultsPage() {
                     ]
                   })
 
+                const filterContainerData = <T extends { timestampMs: number | string }>(
+                  points: T[],
+                ): T[] => {
+                  if (!brushTimeRange) return points
+                  return points.filter(
+                    (p) =>
+                      (p.timestampMs as number) >= brushTimeRange[0] &&
+                      (p.timestampMs as number) <= brushTimeRange[1],
+                  )
+                }
+
+                const visibleContainerCpuData = filterContainerData(host.containerCpu.data)
+                const visibleContainerMemoryData = filterContainerData(host.containerMemory.data)
+                const visibleContainerNetworkData = filterContainerData(host.containerNetwork.data)
+                const visibleContainerBlockData = filterContainerData(host.containerBlock.data)
+
                 const containerCpuDomain = resolveMultiSeriesYAxisDomain(
-                  host.containerCpu.data, host.containerCpu.dataKeys, resourceAxisScaleMode,
+                  visibleContainerCpuData, host.containerCpu.dataKeys, resourceAxisScaleMode,
                 )
                 const containerMemoryDomain = resolveMultiSeriesYAxisDomain(
-                  host.containerMemory.data, host.containerMemory.dataKeys, resourceAxisScaleMode,
+                  visibleContainerMemoryData, host.containerMemory.dataKeys, resourceAxisScaleMode,
                 )
                 const containerNetworkDomain = resolveMultiSeriesYAxisDomain(
-                  host.containerNetwork.data, host.containerNetwork.dataKeys, resourceAxisScaleMode,
+                  visibleContainerNetworkData, host.containerNetwork.dataKeys, resourceAxisScaleMode,
                 )
                 const containerBlockDomain = resolveMultiSeriesYAxisDomain(
-                  host.containerBlock.data, host.containerBlock.dataKeys, resourceAxisScaleMode,
+                  visibleContainerBlockData, host.containerBlock.dataKeys, resourceAxisScaleMode,
                 )
 
                 const derivedCpu = host.derivedSummary?.resource?.cpu
@@ -1249,7 +1269,7 @@ export function BenchmarkRunResultsPage() {
                       <div className="run-results-resource-grid">
                         <ResourceChart
                           title="CPU %"
-                          data={host.machinePoints}
+                          data={visibleMachinePoints}
                           lines={[
                             { dataKey: 'cpuPercentage', name: 'CPU %', color: '#2563eb' },
                           ]}
@@ -1257,21 +1277,19 @@ export function BenchmarkRunResultsPage() {
                           yAxisFormatter={(v) => `${Math.round(v)}%`}
                           tooltipFormatter={cpuTooltipFormatter}
                           showPointsOnly={resourceShowPointsOnly}
-                          xAxisDomain={brushTimeRange ?? undefined}
                         />
                         <ResourceChart
                           title="Memory"
-                          data={host.machinePoints}
+                          data={visibleMachinePoints}
                           lines={machineMemoryLines}
                           yAxisDomain={machineMemoryDomain}
                           yAxisFormatter={(v) => formatBytes(v)}
                           tooltipFormatter={byteTooltipFormatter}
                           showPointsOnly={resourceShowPointsOnly}
-                          xAxisDomain={brushTimeRange ?? undefined}
                         />
                         <ResourceChart
                           title="Network I/O"
-                          data={host.machinePoints}
+                          data={visibleMachinePoints}
                           lines={[
                             { dataKey: 'networkInBytes', name: 'In', color: '#16a34a' },
                             { dataKey: 'networkOutBytes', name: 'Out', color: '#f97316' },
@@ -1280,11 +1298,10 @@ export function BenchmarkRunResultsPage() {
                           yAxisFormatter={(v) => formatBytes(v)}
                           tooltipFormatter={byteTooltipFormatter}
                           showPointsOnly={resourceShowPointsOnly}
-                          xAxisDomain={brushTimeRange ?? undefined}
                         />
                         <ResourceChart
                           title="Block I/O"
-                          data={host.machinePoints}
+                          data={visibleMachinePoints}
                           lines={[
                             { dataKey: 'blockInBytes', name: 'In', color: '#06b6d4' },
                             { dataKey: 'blockOutBytes', name: 'Out', color: '#d97706' },
@@ -1293,7 +1310,6 @@ export function BenchmarkRunResultsPage() {
                           yAxisFormatter={(v) => formatBytes(v)}
                           tooltipFormatter={byteTooltipFormatter}
                           showPointsOnly={resourceShowPointsOnly}
-                          xAxisDomain={brushTimeRange ?? undefined}
                         />
                       </div>
                     </div>
@@ -1345,43 +1361,39 @@ export function BenchmarkRunResultsPage() {
                             <div className="run-results-resource-grid">
                               <ResourceChart
                                 title="CPU %"
-                                data={host.containerCpu.data}
+                                data={visibleContainerCpuData}
                                 lines={containerCpuLines}
                                 yAxisDomain={containerCpuDomain}
                                 yAxisFormatter={(v) => `${Math.round(v)}%`}
                                 tooltipFormatter={cpuTooltipFormatter}
                                 showPointsOnly={resourceShowPointsOnly}
-                                xAxisDomain={brushTimeRange ?? undefined}
                               />
                               <ResourceChart
                                 title="Memory"
-                                data={host.containerMemory.data}
+                                data={visibleContainerMemoryData}
                                 lines={containerMemoryLines}
                                 yAxisDomain={containerMemoryDomain}
                                 yAxisFormatter={(v) => formatBytes(v)}
                                 tooltipFormatter={byteTooltipFormatter}
                                 showPointsOnly={resourceShowPointsOnly}
-                                xAxisDomain={brushTimeRange ?? undefined}
                               />
                               <ResourceChart
                                 title="Network I/O"
-                                data={host.containerNetwork.data}
+                                data={visibleContainerNetworkData}
                                 lines={containerNetworkLines}
                                 yAxisDomain={containerNetworkDomain}
                                 yAxisFormatter={(v) => formatBytes(v)}
                                 tooltipFormatter={byteTooltipFormatter}
                                 showPointsOnly={resourceShowPointsOnly}
-                                xAxisDomain={brushTimeRange ?? undefined}
                               />
                               <ResourceChart
                                 title="Block I/O"
-                                data={host.containerBlock.data}
+                                data={visibleContainerBlockData}
                                 lines={containerBlockLines}
                                 yAxisDomain={containerBlockDomain}
                                 yAxisFormatter={(v) => formatBytes(v)}
                                 tooltipFormatter={byteTooltipFormatter}
                                 showPointsOnly={resourceShowPointsOnly}
-                                xAxisDomain={brushTimeRange ?? undefined}
                               />
                             </div>
                           )}

--- a/src/features/benchmarks/resourceCharting.ts
+++ b/src/features/benchmarks/resourceCharting.ts
@@ -1,0 +1,315 @@
+import type { RawResourceDataPointDTO } from '../../generated/openapi/models/RawResourceDataPointDTO'
+import { formatReadableTimestamp } from '../dateTime'
+import type { AxisDomain, AxisScaleMode } from './charting'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ResourceMetricKey =
+  | 'cpuPercentage'
+  | 'memoryUsageBytes'
+  | 'memoryLimitBytes'
+  | 'networkInBytes'
+  | 'networkOutBytes'
+  | 'blockInBytes'
+  | 'blockOutBytes'
+
+export interface ResourceChartPoint {
+  timestampMs: number
+  timestampLabel: string
+  cpuPercentage: number | null
+  memoryUsageBytes: number | null
+  memoryLimitBytes: number | null
+  networkInBytes: number | null
+  networkOutBytes: number | null
+  blockInBytes: number | null
+  blockOutBytes: number | null
+}
+
+export interface MultiSeriesResourcePoint {
+  timestampMs: number
+  timestampLabel: string
+  [dataKey: string]: string | number | null
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const ALL_RESOURCE_METRICS: ReadonlyArray<ResourceMetricKey> = [
+  'cpuPercentage',
+  'memoryUsageBytes',
+  'memoryLimitBytes',
+  'networkInBytes',
+  'networkOutBytes',
+  'blockInBytes',
+  'blockOutBytes',
+]
+
+const AUTO_DOMAIN: AxisDomain = ['auto', 'auto']
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function toNumericValue(value: number | null | undefined): number | null {
+  if (value == null || Number.isNaN(value)) {
+    return null
+  }
+  return value
+}
+
+function withTightPadding(min: number, max: number): AxisDomain {
+  if (min === max) {
+    const padding = Math.max(Math.abs(min) * 0.1, 1)
+    return [min - padding, max + padding]
+  }
+  const padding = Math.max((max - min) * 0.08, 1)
+  return [min - padding, max + padding]
+}
+
+function computeDomain(
+  min: number,
+  max: number,
+  hasValue: boolean,
+  mode: AxisScaleMode,
+): AxisDomain {
+  if (!hasValue) {
+    return AUTO_DOMAIN
+  }
+  if (mode === 'from-zero') {
+    const paddedMax = max <= 0 ? 1 : max + Math.max(max * 0.05, 1)
+    return [0, paddedMax]
+  }
+  return withTightPadding(min, max)
+}
+
+// ---------------------------------------------------------------------------
+// Single-entity (machine) charting
+// ---------------------------------------------------------------------------
+
+export function normalizeResourceDataPoints(
+  dataPoints: ReadonlyArray<RawResourceDataPointDTO>,
+): Array<ResourceChartPoint> {
+  const points: Array<ResourceChartPoint> = []
+
+  for (const point of dataPoints) {
+    const timestamp = point.timestamp ? new Date(point.timestamp) : null
+    if (!timestamp || Number.isNaN(timestamp.getTime())) {
+      continue
+    }
+
+    points.push({
+      timestampMs: timestamp.getTime(),
+      timestampLabel: formatReadableTimestamp(timestamp) ?? timestamp.toISOString(),
+      cpuPercentage: toNumericValue(point.cpuPercentage),
+      memoryUsageBytes: toNumericValue(point.memoryUsageBytes),
+      memoryLimitBytes: toNumericValue(point.memoryLimitBytes),
+      networkInBytes: toNumericValue(point.networkInBytes),
+      networkOutBytes: toNumericValue(point.networkOutBytes),
+      blockInBytes: toNumericValue(point.blockInBytes),
+      blockOutBytes: toNumericValue(point.blockOutBytes),
+    })
+  }
+
+  points.sort((a, b) => a.timestampMs - b.timestampMs)
+  return points
+}
+
+export function applyResourceSlidingAverage(
+  points: ReadonlyArray<ResourceChartPoint>,
+  windowSize: number,
+): Array<ResourceChartPoint> {
+  if (windowSize <= 1 || points.length === 0) {
+    return [...points]
+  }
+
+  const normalizedWindowSize = Math.max(Math.floor(windowSize), 1)
+  const leftWindowSize = Math.floor((normalizedWindowSize - 1) / 2)
+  const rightWindowSize = Math.ceil((normalizedWindowSize - 1) / 2)
+
+  return points.map((point, index) => {
+    const startIndex = Math.max(index - leftWindowSize, 0)
+    const endIndex = Math.min(index + rightWindowSize, points.length - 1)
+    const averaged: ResourceChartPoint = { ...point }
+
+    for (const metric of ALL_RESOURCE_METRICS) {
+      let sum = 0
+      let count = 0
+      for (let i = startIndex; i <= endIndex; i += 1) {
+        const value = points[i][metric]
+        if (value != null && !Number.isNaN(value)) {
+          sum += value
+          count += 1
+        }
+      }
+      averaged[metric] = count > 0 ? sum / count : null
+    }
+
+    return averaged
+  })
+}
+
+export function resolveResourceYAxisDomain(
+  points: ReadonlyArray<ResourceChartPoint>,
+  metrics: ReadonlyArray<ResourceMetricKey>,
+  mode: AxisScaleMode,
+): AxisDomain {
+  if (mode === 'auto') {
+    return AUTO_DOMAIN
+  }
+
+  let min = Number.POSITIVE_INFINITY
+  let max = Number.NEGATIVE_INFINITY
+  let hasValue = false
+
+  for (const point of points) {
+    for (const metric of metrics) {
+      const value = point[metric]
+      if (value != null && !Number.isNaN(value)) {
+        if (value < min) min = value
+        if (value > max) max = value
+        hasValue = true
+      }
+    }
+  }
+
+  return computeDomain(min, max, hasValue, mode)
+}
+
+// ---------------------------------------------------------------------------
+// Multi-entity (container) charting
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the data-key strings used inside a merged multi-series point.
+ * For each entity × metric combination: `"${entityKey}_${metric}"`.
+ */
+export function getMultiSeriesDataKeys(
+  entityKeys: ReadonlyArray<string>,
+  metrics: ReadonlyArray<ResourceMetricKey>,
+): Array<string> {
+  const keys: Array<string> = []
+  for (const entityKey of entityKeys) {
+    for (const metric of metrics) {
+      keys.push(`${entityKey}_${metric}`)
+    }
+  }
+  return keys
+}
+
+/**
+ * Merges multiple entities' resource data points into a single time-aligned
+ * array suitable for rendering a Recharts chart with one `<Line>` per
+ * entity+metric combination. Data keys follow the pattern
+ * `"${entityKey}_${metricKey}"`.
+ */
+export function mergeResourceSeries(
+  entities: ReadonlyArray<{
+    key: string
+    dataPoints: ReadonlyArray<RawResourceDataPointDTO>
+  }>,
+  metrics: ReadonlyArray<ResourceMetricKey>,
+): Array<MultiSeriesResourcePoint> {
+  const merged = new Map<number, MultiSeriesResourcePoint>()
+  const allDataKeys = getMultiSeriesDataKeys(
+    entities.map((e) => e.key),
+    metrics,
+  )
+
+  for (const entity of entities) {
+    const normalized = normalizeResourceDataPoints(entity.dataPoints)
+    for (const point of normalized) {
+      let row = merged.get(point.timestampMs)
+      if (!row) {
+        row = {
+          timestampMs: point.timestampMs,
+          timestampLabel: point.timestampLabel,
+        }
+        merged.set(point.timestampMs, row)
+      }
+      for (const metric of metrics) {
+        row[`${entity.key}_${metric}`] = point[metric]
+      }
+    }
+  }
+
+  // Fill missing data keys with null so every row has every key
+  for (const row of merged.values()) {
+    for (const dataKey of allDataKeys) {
+      if (!(dataKey in row)) {
+        row[dataKey] = null
+      }
+    }
+  }
+
+  return Array.from(merged.values()).sort(
+    (a, b) => (a.timestampMs as number) - (b.timestampMs as number),
+  )
+}
+
+export function applyMultiSeriesSlidingAverage(
+  points: ReadonlyArray<MultiSeriesResourcePoint>,
+  seriesKeys: ReadonlyArray<string>,
+  windowSize: number,
+): Array<MultiSeriesResourcePoint> {
+  if (windowSize <= 1 || points.length === 0) {
+    return points.map((p) => ({ ...p }))
+  }
+
+  const normalizedWindowSize = Math.max(Math.floor(windowSize), 1)
+  const leftWindowSize = Math.floor((normalizedWindowSize - 1) / 2)
+  const rightWindowSize = Math.ceil((normalizedWindowSize - 1) / 2)
+
+  return points.map((point, index) => {
+    const startIndex = Math.max(index - leftWindowSize, 0)
+    const endIndex = Math.min(index + rightWindowSize, points.length - 1)
+    const averaged: MultiSeriesResourcePoint = {
+      timestampMs: point.timestampMs,
+      timestampLabel: point.timestampLabel,
+    }
+
+    for (const key of seriesKeys) {
+      let sum = 0
+      let count = 0
+      for (let i = startIndex; i <= endIndex; i += 1) {
+        const value = points[i][key]
+        if (typeof value === 'number' && !Number.isNaN(value)) {
+          sum += value
+          count += 1
+        }
+      }
+      averaged[key] = count > 0 ? sum / count : null
+    }
+
+    return averaged
+  })
+}
+
+export function resolveMultiSeriesYAxisDomain(
+  points: ReadonlyArray<MultiSeriesResourcePoint>,
+  seriesKeys: ReadonlyArray<string>,
+  mode: AxisScaleMode,
+): AxisDomain {
+  if (mode === 'auto') {
+    return AUTO_DOMAIN
+  }
+
+  let min = Number.POSITIVE_INFINITY
+  let max = Number.NEGATIVE_INFINITY
+  let hasValue = false
+
+  for (const point of points) {
+    for (const key of seriesKeys) {
+      const value = point[key]
+      if (typeof value === 'number' && !Number.isNaN(value)) {
+        if (value < min) min = value
+        if (value > max) max = value
+        hasValue = true
+      }
+    }
+  }
+
+  return computeDomain(min, max, hasValue, mode)
+}

--- a/src/features/benchmarks/resourceCharting.ts
+++ b/src/features/benchmarks/resourceCharting.ts
@@ -63,10 +63,12 @@ function toNumericValue(value: number | null | undefined): number | null {
 function withTightPadding(min: number, max: number): AxisDomain {
   if (min === max) {
     const padding = Math.max(Math.abs(min) * 0.1, 1)
-    return [min - padding, max + padding]
+    const paddedMin = min - padding
+    return [min >= 0 ? Math.max(0, paddedMin) : paddedMin, max + padding]
   }
   const padding = Math.max((max - min) * 0.08, 1)
-  return [min - padding, max + padding]
+  const paddedMin = min - padding
+  return [min >= 0 ? Math.max(0, paddedMin) : paddedMin, max + padding]
 }
 
 function computeDomain(


### PR DESCRIPTION
## Summary

Closes #75

Adds interactive time-series resource usage charts to the benchmark run results page. Host-level and container/service-level CPU, memory, network I/O, and block I/O are now visualised as Recharts \LineChart\ components beneath the K6 performance charts.

## What was built

- New \esourceCharting.ts\ module with data normalisation, sliding-average smoothing, Y-axis domain resolution, and multi-series merge utilities (mirrors the pattern of \charting.ts\)
- Host-level resource charts: CPU %, Memory, Network I/O, Block I/O
- Per-container/service resource charts (collapsible per host, grouped by service name)
- Chart controls consistent with existing K6 charts: Y-axis scaling (auto / from-zero / tight), smoothing slider, line vs point rendering, series visibility via legend
- **K6 brush zoom globally syncs to all resource charts** — when the user drags the K6 brush, the resource chart data arrays are filtered to the same time window so all charts zoom in unison (Y-axis also re-scales to the visible range)
- Graceful degradation: placeholder shown when a run has no resource data
- Human-readable byte / percentage formatting on all Y-axes and tooltips

## Technical approach for zoom sync

Recharts' \domain\ prop does not hard-clip data (it auto-expands to include all points). The correct approach — matching how Recharts' own \<Brush>\ works — is to **filter the data arrays** to the selected time window before passing them to \LineChart\. A \rushTimeRange: [startMs, endMs] | null\ memo is derived from the K6 brush indices and used to filter each resource series in the render loop.

## Validation

\
pm run lint\ ✅  
\
pm run build\ ✅