### PR TITLE
feat(#76): Resource usage comparison charts on run comparison page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2027,18 +2027,24 @@
 }
 
 .run-comparison-service-section {
-  margin-bottom: 1rem;
+  margin-bottom: 1.2rem;
+  padding: 0.75rem;
+  border: 1px solid #d6e2f1;
+  border-radius: 8px;
+  background: #ffffff;
 }
 
 .run-comparison-service-name {
-  margin: 0 0 0.5rem;
-  font-size: 0.9rem;
-  font-weight: 600;
-  color: #2f475f;
+  margin: 0;
+  padding: 0.3rem 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #17324a;
   display: flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: 0.5rem;
   flex-wrap: wrap;
+  cursor: pointer;
 }
 
 .run-comparison-hosts {

--- a/src/App.css
+++ b/src/App.css
@@ -2047,6 +2047,33 @@
   cursor: pointer;
 }
 
+.run-comparison-chart-summary {
+  font-size: 0.78rem;
+  color: #4b5563;
+  line-height: 1.5;
+  margin-bottom: 0.35rem;
+}
+
+.run-comparison-chart-summary-row {
+  display: flex;
+  gap: 0.35rem;
+  align-items: baseline;
+  flex-wrap: wrap;
+}
+
+.run-comparison-chart-summary-label {
+  font-weight: 700;
+  min-width: 1.1rem;
+}
+
+.run-comparison-label-a {
+  color: #2563eb;
+}
+
+.run-comparison-label-b {
+  color: #dc2626;
+}
+
 .run-comparison-hosts {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/src/App.css
+++ b/src/App.css
@@ -2080,6 +2080,44 @@
   color: #dc2626;
 }
 
+/* Custom comparison chart tooltip */
+.run-comparison-tooltip {
+  background: #fff;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  padding: 0.5rem 0.65rem;
+  font-size: 0.8rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+  min-width: 140px;
+}
+.run-comparison-tooltip-label {
+  font-weight: 600;
+  margin-bottom: 0.3rem;
+  color: #374151;
+}
+.run-comparison-tooltip-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 1px 0;
+}
+.run-comparison-tooltip-swatch {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+.run-comparison-tooltip-name {
+  flex: 1;
+  color: #4b5563;
+}
+.run-comparison-tooltip-value {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: #111827;
+}
+
 .run-comparison-hosts {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/src/App.css
+++ b/src/App.css
@@ -1982,6 +1982,65 @@
   font-size: 0.95rem;
 }
 
+.run-comparison-host-card {
+  border: 1px solid #d6e2f1;
+  border-radius: 10px;
+  background: #f8fbff;
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 0.55rem;
+}
+
+.run-comparison-host-card-summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: #17324a;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.run-comparison-host-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.5rem;
+  font-size: 0.76rem;
+  font-weight: 600;
+  border-radius: 999px;
+  background: #fef3c7;
+  color: #92400e;
+  border: 1px solid #fcd34d;
+}
+
+.run-comparison-host-machine-section,
+.run-comparison-host-container-section {
+  padding-top: 0.75rem;
+  margin-top: 0.5rem;
+  border-top: 1px solid #e5eaf3;
+}
+
+.run-comparison-host-machine-section h4,
+.run-comparison-host-container-section h4 {
+  margin: 0 0 0.5rem;
+  color: #17324a;
+  font-size: 0.95rem;
+}
+
+.run-comparison-service-section {
+  margin-bottom: 1rem;
+}
+
+.run-comparison-service-name {
+  margin: 0 0 0.5rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #2f475f;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
 .run-comparison-hosts {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/src/App.css
+++ b/src/App.css
@@ -2047,11 +2047,17 @@
   cursor: pointer;
 }
 
+.run-comparison-chart-header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
 .run-comparison-chart-summary {
   font-size: 0.78rem;
   color: #4b5563;
   line-height: 1.5;
-  margin-bottom: 0.35rem;
 }
 
 .run-comparison-chart-summary-row {

--- a/src/features/benchmarks/BenchmarkRunComparisonPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunComparisonPage.tsx
@@ -353,44 +353,76 @@ function ResourceComparisonChart({
     })
   }, [])
 
+  const runSpanMs = useMemo(() => {
+    if (data.length < 2) return 0
+    const first = (data[0] as Record<string, unknown>).elapsedMs
+    const last = (data[data.length - 1] as Record<string, unknown>).elapsedMs
+    return typeof first === 'number' && typeof last === 'number' ? last - first : 0
+  }, [data])
+
   const renderTooltip = useCallback(
     (props: Record<string, unknown>) => {
-      const { active, label, payload } = props as {
+      const { active, label } = props as {
         active?: boolean
         label?: number | string
-        payload?: Array<{
-          dataKey?: string
-          name?: string
-          value?: number | null
-          color?: string
-        }>
       }
-      if (!active || !payload || payload.length === 0) return null
+      if (!active || typeof label !== 'number') return null
+
+      const tolerance = runSpanMs * 0.01
+
+      const resolveValue = (dataKey: string): number | null => {
+        // Binary-ish search: find the nearest point with a non-null value
+        let bestVal: number | null = null
+        let bestDist = Infinity
+        for (let i = 0; i < data.length; i++) {
+          const pt = data[i] as Record<string, unknown>
+          const elapsed = pt.elapsedMs as number
+          const dist = Math.abs(elapsed - label)
+          if (dist > tolerance) {
+            if (elapsed > label + tolerance) break
+            continue
+          }
+          const v = pt[dataKey]
+          if (typeof v === 'number' && !Number.isNaN(v)) {
+            if (dist < bestDist) {
+              bestDist = dist
+              bestVal = v
+            }
+          }
+        }
+        return bestVal
+      }
+
+      const entries = lines
+        .filter((l) => !hiddenLines.has(l.dataKey))
+        .map((l) => ({
+          ...l,
+          resolved: resolveValue(l.dataKey),
+        }))
+
+      if (entries.every((e) => e.resolved === null)) return null
+
       return (
         <div className="run-comparison-tooltip">
           <div className="run-comparison-tooltip-label">
             {formatElapsedTooltipLabel(label)}
           </div>
-          {payload
-            .filter((p) => !hiddenLines.has(p.dataKey ?? ''))
-            .map((p) => (
-              <div key={p.dataKey} className="run-comparison-tooltip-row">
-                <span
-                  className="run-comparison-tooltip-swatch"
-                  style={{ background: p.color }}
-                />
-                <span className="run-comparison-tooltip-name">{p.name}</span>
-                <span className="run-comparison-tooltip-value">
-                  {typeof p.value === 'number' && !Number.isNaN(p.value)
-                    ? valueFormatter(p.value)
-                    : 'n/a'}
-                </span>
-              </div>
-            ))}
+          {entries.map((e) => (
+            <div key={e.dataKey} className="run-comparison-tooltip-row">
+              <span
+                className="run-comparison-tooltip-swatch"
+                style={{ background: e.color }}
+              />
+              <span className="run-comparison-tooltip-name">{e.name}</span>
+              <span className="run-comparison-tooltip-value">
+                {e.resolved !== null ? valueFormatter(e.resolved) : 'n/a'}
+              </span>
+            </div>
+          ))}
         </div>
       )
     },
-    [hiddenLines, valueFormatter],
+    [data, lines, hiddenLines, valueFormatter, runSpanMs],
   )
 
   if (data.length === 0) {

--- a/src/features/benchmarks/BenchmarkRunComparisonPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunComparisonPage.tsx
@@ -687,11 +687,19 @@ export function BenchmarkRunComparisonPage() {
             )
           : smoothedSvcPoints
 
+        const svcMemoryMetrics: ResourceComparisonMetricKey[] = [
+          'memoryUsageBytes_A', 'memoryUsageBytes_B',
+        ]
+        if (svc.hasMemoryLimitA) svcMemoryMetrics.push('memoryLimitBytes_A')
+        if (svc.hasMemoryLimitB) svcMemoryMetrics.push('memoryLimitBytes_B')
+
         return {
           serviceKey: svc.serviceKey,
           serviceName: svc.serviceName,
           hasA: svc.hasA,
           hasB: svc.hasB,
+          hasMemoryLimitA: svc.hasMemoryLimitA,
+          hasMemoryLimitB: svc.hasMemoryLimitB,
           derivedResourceA: svc.derivedResourceA,
           derivedResourceB: svc.derivedResourceB,
           visiblePoints: visibleSvcPoints,
@@ -702,7 +710,7 @@ export function BenchmarkRunComparisonPage() {
           ),
           memoryDomain: resolveResourceComparisonYAxisDomain(
             visibleSvcPoints,
-            ['memoryUsageBytes_A', 'memoryUsageBytes_B'],
+            svcMemoryMetrics,
             resourceAxisScaleMode,
           ),
           networkDomain: resolveResourceComparisonYAxisDomain(
@@ -1377,23 +1385,44 @@ export function BenchmarkRunComparisonPage() {
                                           svc.derivedResourceB?.cpu,
                                         )}
                                       />
-                                      <ResourceComparisonChart
-                                        title="Memory"
-                                        data={svc.visiblePoints}
-                                        lines={[
+                                      {(() => {
+                                        const svcMemLines: ResourceCompLineConfig[] = [
                                           { dataKey: 'memoryUsageBytes_A', name: 'Usage (A)', color: '#2563eb' },
                                           { dataKey: 'memoryUsageBytes_B', name: 'Usage (B)', color: '#dc2626' },
-                                        ]}
-                                        yAxisDomain={svc.memoryDomain}
-                                        yAxisFormatter={(v) => formatBytes(v)}
-                                        tooltipFormatter={compByteTooltipFormatter}
-                                        showPointsOnly={resourceShowPointsOnly}
-                                        summaryContent={buildMemorySummary(
-                                          svc.derivedResourceA?.memory,
-                                          svc.derivedResourceB?.memory,
-                                          svc.visiblePoints,
-                                        )}
-                                      />
+                                        ]
+                                        if (svc.hasMemoryLimitA) {
+                                          svcMemLines.push({
+                                            dataKey: 'memoryLimitBytes_A',
+                                            name: 'Limit (A)',
+                                            color: '#93c5fd',
+                                            dashPattern: '10 4',
+                                          })
+                                        }
+                                        if (svc.hasMemoryLimitB) {
+                                          svcMemLines.push({
+                                            dataKey: 'memoryLimitBytes_B',
+                                            name: 'Limit (B)',
+                                            color: '#fca5a5',
+                                            dashPattern: '10 4',
+                                          })
+                                        }
+                                        return (
+                                          <ResourceComparisonChart
+                                            title="Memory"
+                                            data={svc.visiblePoints}
+                                            lines={svcMemLines}
+                                            yAxisDomain={svc.memoryDomain}
+                                            yAxisFormatter={(v) => formatBytes(v)}
+                                            tooltipFormatter={compByteTooltipFormatter}
+                                            showPointsOnly={resourceShowPointsOnly}
+                                            summaryContent={buildMemorySummary(
+                                              svc.derivedResourceA?.memory,
+                                              svc.derivedResourceB?.memory,
+                                              svc.visiblePoints,
+                                            )}
+                                          />
+                                        )
+                                      })()}
                                       <ResourceComparisonChart
                                         title="Network I/O"
                                         data={svc.visiblePoints}

--- a/src/features/benchmarks/BenchmarkRunComparisonPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunComparisonPage.tsx
@@ -266,9 +266,18 @@ function buildMemorySummary(
   memB?: DerivedResourceStatsDTO | null,
   data?: object[],
 ): React.ReactNode {
-  if (!memA && !memB) return null
   const statsA = data ? computePointStats(data, 'memoryUsageBytes_A') : { avg: null, max: null }
   const statsB = data ? computePointStats(data, 'memoryUsageBytes_B') : { avg: null, max: null }
+  if (
+    !memA &&
+    !memB &&
+    statsA.avg == null &&
+    statsA.max == null &&
+    statsB.avg == null &&
+    statsB.max == null
+  ) {
+    return null
+  }
   return (
     <div className="run-comparison-chart-summary">
       {(memA || statsA.avg != null) && (
@@ -336,7 +345,7 @@ function ResourceComparisonChart({
   showPointsOnly: boolean
   summaryContent?: React.ReactNode
 }) {
-  const [hiddenLines, setHiddenLines] = useState<Set<string>>(new Set())
+  const [hiddenLines, setHiddenLines] = useState<Set<string>>(() => new Set())
 
   const handleLegendClick = useCallback((entry: unknown) => {
     if (!entry || typeof entry !== 'object' || !('dataKey' in entry)) return
@@ -369,25 +378,37 @@ function ResourceComparisonChart({
       if (!active || typeof label !== 'number') return null
 
       const tolerance = runSpanMs * 0.01
+      const minElapsed = label - tolerance
+      const maxElapsed = label + tolerance
+
+      const findStartIndex = (targetElapsed: number): number => {
+        let low = 0
+        let high = data.length
+        while (low < high) {
+          const mid = Math.floor((low + high) / 2)
+          const pt = data[mid] as Record<string, unknown>
+          const elapsed = pt.elapsedMs as number
+          if (elapsed < targetElapsed) {
+            low = mid + 1
+          } else {
+            high = mid
+          }
+        }
+        return low
+      }
 
       const resolveValue = (dataKey: string): number | null => {
-        // Binary-ish search: find the nearest point with a non-null value
         let bestVal: number | null = null
         let bestDist = Infinity
-        for (let i = 0; i < data.length; i++) {
+        for (let i = findStartIndex(minElapsed); i < data.length; i++) {
           const pt = data[i] as Record<string, unknown>
           const elapsed = pt.elapsedMs as number
+          if (elapsed > maxElapsed) break
           const dist = Math.abs(elapsed - label)
-          if (dist > tolerance) {
-            if (elapsed > label + tolerance) break
-            continue
-          }
           const v = pt[dataKey]
-          if (typeof v === 'number' && !Number.isNaN(v)) {
-            if (dist < bestDist) {
-              bestDist = dist
-              bestVal = v
-            }
+          if (typeof v === 'number' && !Number.isNaN(v) && dist < bestDist) {
+            bestDist = dist
+            bestVal = v
           }
         }
         return bestVal

--- a/src/features/benchmarks/BenchmarkRunComparisonPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunComparisonPage.tsx
@@ -1315,8 +1315,8 @@ export function BenchmarkRunComparisonPage() {
                               {host.services
                                 .filter((s) => host.selectedServiceKeys.has(s.serviceKey))
                                 .map((svc) => (
-                                  <div key={svc.serviceKey} className="run-comparison-service-section">
-                                    <h5 className="run-comparison-service-name">
+                                  <details key={svc.serviceKey} className="run-comparison-service-section" open>
+                                    <summary className="run-comparison-service-name">
                                       {svc.serviceName}
                                       {!svc.hasA && (
                                         <span className="run-comparison-host-badge">Only in Run B</span>
@@ -1324,7 +1324,7 @@ export function BenchmarkRunComparisonPage() {
                                       {!svc.hasB && (
                                         <span className="run-comparison-host-badge">Only in Run A</span>
                                       )}
-                                    </h5>
+                                    </summary>
                                     <div className="run-results-resource-grid">
                                       <ResourceComparisonChart
                                         title="CPU %"
@@ -1433,7 +1433,7 @@ export function BenchmarkRunComparisonPage() {
                                         showPointsOnly={resourceShowPointsOnly}
                                       />
                                     </div>
-                                  </div>
+                                  </details>
                                 ))}
                             </>
                           )}

--- a/src/features/benchmarks/BenchmarkRunComparisonPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunComparisonPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import {
   Brush,
@@ -14,7 +14,7 @@ import {
 import type { DerivedHttpSummaryDTO } from '../../generated/openapi/models/DerivedHttpSummaryDTO'
 import { getEnvironmentDetails } from '../environments/service'
 import { AsyncStateView } from '../ui/async-state/AsyncState'
-import type { AxisScaleMode } from './charting'
+import type { AxisDomain, AxisScaleMode } from './charting'
 import {
   applyComparisonSlidingAverage,
   COMPARISON_MS_METRICS,
@@ -23,6 +23,12 @@ import {
   mergeK6ChartPointsByElapsed,
   resolveComparisonYAxisDomain,
 } from './comparisonCharting'
+import {
+  applyResourceComparisonSlidingAverage,
+  matchHosts,
+  resolveResourceComparisonYAxisDomain,
+  type ResourceComparisonMetricKey,
+} from './resourceComparisonCharting'
 import {
   BenchmarkRunDetailsError,
   getBenchmark,
@@ -174,6 +180,138 @@ const SERIES_CONFIG: Array<{
   { dataKey: 'vus_B', name: 'VUs (B)', yAxisId: 'vus', color: '#a855f7', dashPattern: '10 4', width: 2.5 },
 ]
 
+function formatElapsedAxisTick(value: number | string): string {
+  const ms = typeof value === 'number' ? value : Number(value)
+  if (Number.isNaN(ms)) return ''
+  const totalSeconds = Math.floor(ms / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  if (minutes > 0) return `${minutes}m ${seconds.toString().padStart(2, '0')}s`
+  return `${seconds}s`
+}
+
+function formatElapsedTooltipLabel(label: unknown): string {
+  if (typeof label !== 'number') return String(label ?? '')
+  return formatElapsedAxisTick(label)
+}
+
+interface ResourceCompLineConfig {
+  dataKey: string
+  name: string
+  color: string
+  dashPattern?: string
+}
+
+function makeCompResourceTooltipFormatter(isByteMetric: boolean) {
+  return (
+    value: number | string | ReadonlyArray<number | string> | null | undefined,
+    name: number | string | undefined,
+  ): [string, string] => {
+    const label = typeof name === 'undefined' ? 'Value' : String(name)
+    const normalizedValue = Array.isArray(value) ? value[0] : value
+    if (typeof normalizedValue !== 'number' || Number.isNaN(normalizedValue)) {
+      return ['n/a', label]
+    }
+    return isByteMetric
+      ? [formatBytes(normalizedValue), label]
+      : [`${normalizedValue.toFixed(1)}%`, label]
+  }
+}
+
+const compCpuTooltipFormatter = makeCompResourceTooltipFormatter(false)
+const compByteTooltipFormatter = makeCompResourceTooltipFormatter(true)
+
+function ResourceComparisonChart({
+  title,
+  data,
+  lines,
+  yAxisDomain,
+  yAxisFormatter,
+  tooltipFormatter,
+  showPointsOnly,
+}: {
+  title: string
+  data: object[]
+  lines: ResourceCompLineConfig[]
+  yAxisDomain: AxisDomain
+  yAxisFormatter: (value: number) => string
+  tooltipFormatter: (
+    value: number | string | ReadonlyArray<number | string> | null | undefined,
+    name: number | string | undefined,
+  ) => [string, string]
+  showPointsOnly: boolean
+}) {
+  const [hiddenLines, setHiddenLines] = useState<Set<string>>(new Set())
+
+  const handleLegendClick = useCallback((entry: unknown) => {
+    if (!entry || typeof entry !== 'object' || !('dataKey' in entry)) return
+    const dataKey = (entry as { dataKey?: string }).dataKey
+    if (typeof dataKey !== 'string') return
+    setHiddenLines((current) => {
+      const next = new Set(current)
+      if (next.has(dataKey)) {
+        next.delete(dataKey)
+      } else {
+        next.add(dataKey)
+      }
+      return next
+    })
+  }, [])
+
+  if (data.length === 0) {
+    return (
+      <div className="run-results-resource-chart-wrap">
+        <h4 className="run-results-resource-chart-title">{title}</h4>
+        <p className="run-results-placeholder">No data</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="run-results-resource-chart-wrap">
+      <h4 className="run-results-resource-chart-title">{title}</h4>
+      <ResponsiveContainer width="100%" height={200}>
+        <LineChart data={data} margin={{ top: 4, right: 8, left: 0, bottom: 4 }}>
+          <CartesianGrid stroke="#d9e2ef" strokeDasharray="3 3" />
+          <XAxis
+            dataKey="elapsedMs"
+            type="number"
+            domain={['dataMin', 'dataMax']}
+            minTickGap={42}
+            tickFormatter={formatElapsedAxisTick}
+          />
+          <YAxis domain={yAxisDomain} tickFormatter={yAxisFormatter} width={68} />
+          <Tooltip
+            formatter={tooltipFormatter}
+            labelFormatter={formatElapsedTooltipLabel}
+            isAnimationActive={false}
+          />
+          <Legend onClick={handleLegendClick} />
+          {lines.map((line) => (
+            <Line
+              key={line.dataKey}
+              type="linear"
+              dataKey={line.dataKey}
+              name={line.name}
+              stroke={line.color}
+              strokeDasharray={line.dashPattern}
+              strokeWidth={showPointsOnly ? 0.0001 : 2}
+              dot={
+                showPointsOnly
+                  ? { r: 3, fill: line.color, stroke: line.color, strokeWidth: 1 }
+                  : false
+              }
+              activeDot={{ r: 4, fill: line.color, stroke: line.color }}
+              connectNulls
+              hide={hiddenLines.has(line.dataKey)}
+            />
+          ))}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
 export function BenchmarkRunComparisonPage() {
   const {
     environmentId = '',
@@ -201,6 +339,12 @@ export function BenchmarkRunComparisonPage() {
   const [visibleSeries, setVisibleSeries] = useState<ComparisonSeriesVisibility>(DEFAULT_SERIES_VISIBILITY)
   const [brushRange, setBrushRange] = useState<BrushRange | null>(null)
   const [selectedPercentiles, setSelectedPercentiles] = useState<Set<string> | null>(null)
+  const [resourceAxisScaleMode, setResourceAxisScaleMode] = useState<AxisScaleMode>('auto')
+  const [resourceChartRenderMode, setResourceChartRenderMode] = useState<ChartRenderMode>('line')
+  const [resourceSmoothingLevel, setResourceSmoothingLevel] = useState(0)
+  const [selectedCompServiceKeysByHost, setSelectedCompServiceKeysByHost] = useState<
+    Record<string, Set<string>>
+  >({})
 
   const environmentLabel = (environmentName ?? environmentId).trim() || 'n/a'
   const benchmarkLabel = (benchmarkName ?? benchmarkId).trim() || 'n/a'
@@ -268,9 +412,6 @@ export function BenchmarkRunComparisonPage() {
   const httpB = useMemo(() => [...(comparisonData?.derivedB?.http ?? [])].sort((a, b) => (b.totalRequests ?? 0) - (a.totalRequests ?? 0)), [comparisonData])
   const vusA = comparisonData?.derivedA?.vus
   const vusB = comparisonData?.derivedB?.vus
-  const hostsA = useMemo(() => [...(comparisonData?.derivedA?.hosts ?? [])].sort((a, b) => (a.hostName ?? '').localeCompare(b.hostName ?? '')), [comparisonData])
-  const hostsB = useMemo(() => [...(comparisonData?.derivedB?.hosts ?? [])].sort((a, b) => (a.hostName ?? '').localeCompare(b.hostName ?? '')), [comparisonData])
-
   const matchedHttpGroups = useMemo(() => matchHttpGroups(httpA, httpB), [httpA, httpB])
   const percentileKeys = useMemo(() => collectPercentileKeys(httpA, httpB), [httpA, httpB])
 
@@ -359,6 +500,177 @@ export function BenchmarkRunComparisonPage() {
     const dataKey = toComparisonMetricKey((entry as { dataKey?: unknown }).dataKey)
     if (!dataKey) return
     setVisibleSeries((current) => ({ ...current, [dataKey]: !current[dataKey] }))
+  }
+
+  const resourceCompSmoothingWindowSize = resourceSmoothingLevel === 0 ? 1 : resourceSmoothingLevel + 1
+
+  const resourceBrushElapsedRange = useMemo<[number, number] | null>(() => {
+    if (chartPoints.length === 0) return null
+    return [chartPoints[brushStartIndex].elapsedMs, chartPoints[brushEndIndex].elapsedMs]
+  }, [brushStartIndex, brushEndIndex, chartPoints])
+
+  const processedComparisonHosts = useMemo(() => {
+    if (!comparisonData) return []
+    const matched = matchHosts(
+      comparisonData.rawA,
+      comparisonData.rawB,
+      comparisonData.derivedA,
+      comparisonData.derivedB,
+    )
+    return matched.map((host) => {
+      const selectedServiceKeys =
+        selectedCompServiceKeysByHost[host.hostKey] ??
+        new Set(host.services.map((s) => s.serviceKey))
+
+      const smoothedMachinePoints = applyResourceComparisonSlidingAverage(
+        host.baseComparisonPoints,
+        resourceCompSmoothingWindowSize,
+      )
+      const visibleMachinePoints = resourceBrushElapsedRange
+        ? smoothedMachinePoints.filter(
+            (p) =>
+              p.elapsedMs >= resourceBrushElapsedRange[0] &&
+              p.elapsedMs <= resourceBrushElapsedRange[1],
+          )
+        : smoothedMachinePoints
+
+      const machineCpuDomain = resolveResourceComparisonYAxisDomain(
+        visibleMachinePoints,
+        ['cpuPercentage_A', 'cpuPercentage_B'],
+        resourceAxisScaleMode,
+      )
+      const machineMemoryMetrics: ResourceComparisonMetricKey[] = [
+        'memoryUsageBytes_A',
+        'memoryUsageBytes_B',
+      ]
+      if (host.hasMemoryLimitA) machineMemoryMetrics.push('memoryLimitBytes_A')
+      if (host.hasMemoryLimitB) machineMemoryMetrics.push('memoryLimitBytes_B')
+      const machineMemoryDomain = resolveResourceComparisonYAxisDomain(
+        visibleMachinePoints,
+        machineMemoryMetrics,
+        resourceAxisScaleMode,
+      )
+      const machineNetworkDomain = resolveResourceComparisonYAxisDomain(
+        visibleMachinePoints,
+        ['networkInBytes_A', 'networkInBytes_B', 'networkOutBytes_A', 'networkOutBytes_B'],
+        resourceAxisScaleMode,
+      )
+      const machineBlockDomain = resolveResourceComparisonYAxisDomain(
+        visibleMachinePoints,
+        ['blockInBytes_A', 'blockInBytes_B', 'blockOutBytes_A', 'blockOutBytes_B'],
+        resourceAxisScaleMode,
+      )
+
+      const services = host.services.map((svc) => {
+        const smoothedSvcPoints = applyResourceComparisonSlidingAverage(
+          svc.baseComparisonPoints,
+          resourceCompSmoothingWindowSize,
+        )
+        const visibleSvcPoints = resourceBrushElapsedRange
+          ? smoothedSvcPoints.filter(
+              (p) =>
+                p.elapsedMs >= resourceBrushElapsedRange[0] &&
+                p.elapsedMs <= resourceBrushElapsedRange[1],
+            )
+          : smoothedSvcPoints
+
+        return {
+          serviceKey: svc.serviceKey,
+          serviceName: svc.serviceName,
+          hasA: svc.hasA,
+          hasB: svc.hasB,
+          visiblePoints: visibleSvcPoints,
+          cpuDomain: resolveResourceComparisonYAxisDomain(
+            visibleSvcPoints,
+            ['cpuPercentage_A', 'cpuPercentage_B'],
+            resourceAxisScaleMode,
+          ),
+          memoryDomain: resolveResourceComparisonYAxisDomain(
+            visibleSvcPoints,
+            ['memoryUsageBytes_A', 'memoryUsageBytes_B'],
+            resourceAxisScaleMode,
+          ),
+          networkDomain: resolveResourceComparisonYAxisDomain(
+            visibleSvcPoints,
+            ['networkInBytes_A', 'networkInBytes_B', 'networkOutBytes_A', 'networkOutBytes_B'],
+            resourceAxisScaleMode,
+          ),
+          blockDomain: resolveResourceComparisonYAxisDomain(
+            visibleSvcPoints,
+            ['blockInBytes_A', 'blockInBytes_B', 'blockOutBytes_A', 'blockOutBytes_B'],
+            resourceAxisScaleMode,
+          ),
+        }
+      })
+
+      return {
+        hostKey: host.hostKey,
+        hostName: host.hostName,
+        hasA: host.hasA,
+        hasB: host.hasB,
+        derivedA: host.derivedA,
+        derivedB: host.derivedB,
+        hasMemoryLimitA: host.hasMemoryLimitA,
+        hasMemoryLimitB: host.hasMemoryLimitB,
+        selectedServiceKeys,
+        visibleMachinePoints,
+        machineCpuDomain,
+        machineMemoryDomain,
+        machineNetworkDomain,
+        machineBlockDomain,
+        services,
+      }
+    })
+  }, [
+    comparisonData,
+    resourceAxisScaleMode,
+    resourceBrushElapsedRange,
+    resourceCompSmoothingWindowSize,
+    selectedCompServiceKeysByHost,
+  ])
+
+  useEffect(() => {
+    if (!comparisonData) {
+      setSelectedCompServiceKeysByHost({})
+      return
+    }
+    const matched = matchHosts(
+      comparisonData.rawA,
+      comparisonData.rawB,
+      comparisonData.derivedA,
+      comparisonData.derivedB,
+    )
+    const initial: Record<string, Set<string>> = {}
+    for (const host of matched) {
+      initial[host.hostKey] = new Set(host.services.map((s) => s.serviceKey))
+    }
+    setSelectedCompServiceKeysByHost(initial)
+  }, [comparisonData])
+
+  const handleToggleCompService = (hostKey: string, serviceKey: string) => {
+    setSelectedCompServiceKeysByHost((current) => {
+      const hostSet = new Set(current[hostKey] ?? [])
+      if (hostSet.has(serviceKey)) {
+        hostSet.delete(serviceKey)
+      } else {
+        hostSet.add(serviceKey)
+      }
+      return { ...current, [hostKey]: hostSet }
+    })
+  }
+
+  const handleSelectAllCompServices = (hostKey: string, allKeys: string[]) => {
+    setSelectedCompServiceKeysByHost((current) => ({
+      ...current,
+      [hostKey]: new Set(allKeys),
+    }))
+  }
+
+  const handleSelectNoCompServices = (hostKey: string) => {
+    setSelectedCompServiceKeysByHost((current) => ({
+      ...current,
+      [hostKey]: new Set<string>(),
+    }))
   }
 
   const runIdAShort = runIdA.slice(0, 8)
@@ -759,45 +1071,379 @@ export function BenchmarkRunComparisonPage() {
         {/* Host resources comparison */}
         <section className="run-results-section">
           <h2>Host resources</h2>
-          {hostsA.length === 0 && hostsB.length === 0 ? (
+          {processedComparisonHosts.length === 0 ? (
             <p className="run-results-placeholder">
               No host resource data available for comparison.
             </p>
           ) : (
-            <div className="run-comparison-hosts">
-              <div className="run-comparison-host-panel">
-                <h3>Run A hosts</h3>
-                {hostsA.length === 0 ? (
-                  <p>No host data available.</p>
-                ) : (
-                  <ul className="run-results-host-list">
-                    {hostsA.map((host) => (
-                      <li key={`a-${host.hostId ?? host.hostName ?? ''}`}>
-                        <h4>{host.hostName ?? host.hostId ?? 'Host'}</h4>
-                        <p>CPU avg {formatMetric(host.resource?.cpu?.avg, '%')} | Mem avg {formatMetric(host.resource?.memory?.avg, '%')}</p>
-                        <p>Net in {formatBytes(host.resource?.networkInTotalBytes)} | Net out {formatBytes(host.resource?.networkOutTotalBytes)}</p>
-                      </li>
-                    ))}
-                  </ul>
-                )}
+            <>
+              <div className="run-results-chart-controls">
+                <div className="run-results-axis-mode-group" role="group" aria-label="Resource Y-axis scale">
+                  {AXIS_MODE_OPTIONS.map((option) => (
+                    <button
+                      key={option.value}
+                      type="button"
+                      className={`shell-alert-dismiss run-results-axis-mode-button${resourceAxisScaleMode === option.value ? ' is-selected' : ''}`}
+                      onClick={() => setResourceAxisScaleMode(option.value)}
+                      aria-pressed={resourceAxisScaleMode === option.value}
+                      title={option.description}
+                    >
+                      {option.label}
+                    </button>
+                  ))}
+                </div>
+                <div className="run-results-axis-mode-group" role="group" aria-label="Resource render mode">
+                  {CHART_RENDER_MODE_OPTIONS.map((option) => (
+                    <button
+                      key={option.value}
+                      type="button"
+                      className={`shell-alert-dismiss run-results-axis-mode-button${resourceChartRenderMode === option.value ? ' is-selected' : ''}`}
+                      onClick={() => setResourceChartRenderMode(option.value)}
+                      aria-pressed={resourceChartRenderMode === option.value}
+                      title={option.description}
+                    >
+                      {option.label}
+                    </button>
+                  ))}
+                </div>
+                <div className="run-results-smoothing-slider-group">
+                  <label
+                    className="run-results-smoothing-slider-label"
+                    htmlFor="resource-comparison-smoothing-slider"
+                  >
+                    Sliding average: {resourceSmoothingLevel === 0 ? 'Raw' : resourceSmoothingLevel}
+                  </label>
+                  <input
+                    id="resource-comparison-smoothing-slider"
+                    className="run-results-smoothing-slider-input"
+                    type="range"
+                    min={0}
+                    max={9}
+                    step={1}
+                    value={resourceSmoothingLevel}
+                    onChange={(e) => {
+                      const next = Number(e.currentTarget.value)
+                      if (!Number.isNaN(next))
+                        setResourceSmoothingLevel(Math.min(Math.max(next, 0), 9))
+                    }}
+                    aria-label="Resource sliding average level from 0 to 9"
+                  />
+                  <div className="run-results-smoothing-slider-marks" aria-hidden="true">
+                    <span>Raw</span>
+                    <span>5</span>
+                    <span>9</span>
+                  </div>
+                </div>
               </div>
-              <div className="run-comparison-host-panel">
-                <h3>Run B hosts</h3>
-                {hostsB.length === 0 ? (
-                  <p>No host data available.</p>
-                ) : (
-                  <ul className="run-results-host-list">
-                    {hostsB.map((host) => (
-                      <li key={`b-${host.hostId ?? host.hostName ?? ''}`}>
-                        <h4>{host.hostName ?? host.hostId ?? 'Host'}</h4>
-                        <p>CPU avg {formatMetric(host.resource?.cpu?.avg, '%')} | Mem avg {formatMetric(host.resource?.memory?.avg, '%')}</p>
-                        <p>Net in {formatBytes(host.resource?.networkInTotalBytes)} | Net out {formatBytes(host.resource?.networkOutTotalBytes)}</p>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </div>
-            </div>
+
+              {processedComparisonHosts.map((host) => {
+                const resourceShowPointsOnly = resourceChartRenderMode === 'points'
+                const memoryLines: ResourceCompLineConfig[] = [
+                  { dataKey: 'memoryUsageBytes_A', name: 'Usage (A)', color: '#8b5cf6' },
+                  {
+                    dataKey: 'memoryUsageBytes_B',
+                    name: 'Usage (B)',
+                    color: '#d946ef',
+                    dashPattern: '10 4',
+                  },
+                ]
+                if (host.hasMemoryLimitA) {
+                  memoryLines.push({
+                    dataKey: 'memoryLimitBytes_A',
+                    name: 'Limit (A)',
+                    color: '#94a3b8',
+                  })
+                }
+                if (host.hasMemoryLimitB) {
+                  memoryLines.push({
+                    dataKey: 'memoryLimitBytes_B',
+                    name: 'Limit (B)',
+                    color: '#64748b',
+                    dashPattern: '10 4',
+                  })
+                }
+
+                return (
+                  <details key={host.hostKey} className="run-comparison-host-card" open>
+                    <summary className="run-comparison-host-card-summary">
+                      <span className="run-results-host-card-name">{host.hostName}</span>
+                      {!host.hasA && (
+                        <span className="run-comparison-host-badge">Only in Run B</span>
+                      )}
+                      {!host.hasB && (
+                        <span className="run-comparison-host-badge">Only in Run A</span>
+                      )}
+                      <span className="run-results-host-card-stats">
+                        CPU avg A: {formatMetric(host.derivedA?.resource?.cpu?.avg, '%')} B:{' '}
+                        {formatMetric(host.derivedB?.resource?.cpu?.avg, '%')}
+                        {' | '}
+                        Mem avg A: {formatMetric(host.derivedA?.resource?.memory?.avg, '%')} B:{' '}
+                        {formatMetric(host.derivedB?.resource?.memory?.avg, '%')}
+                      </span>
+                    </summary>
+
+                    <div className="run-comparison-host-machine-section">
+                      <h4>Machine</h4>
+                      <div className="run-results-resource-grid">
+                        <ResourceComparisonChart
+                          title="CPU %"
+                          data={host.visibleMachinePoints}
+                          lines={[
+                            { dataKey: 'cpuPercentage_A', name: 'CPU % (A)', color: '#2563eb' },
+                            {
+                              dataKey: 'cpuPercentage_B',
+                              name: 'CPU % (B)',
+                              color: '#dc2626',
+                              dashPattern: '10 4',
+                            },
+                          ]}
+                          yAxisDomain={host.machineCpuDomain}
+                          yAxisFormatter={(v) => `${Math.round(v)}%`}
+                          tooltipFormatter={compCpuTooltipFormatter}
+                          showPointsOnly={resourceShowPointsOnly}
+                        />
+                        <ResourceComparisonChart
+                          title="Memory"
+                          data={host.visibleMachinePoints}
+                          lines={memoryLines}
+                          yAxisDomain={host.machineMemoryDomain}
+                          yAxisFormatter={(v) => formatBytes(v)}
+                          tooltipFormatter={compByteTooltipFormatter}
+                          showPointsOnly={resourceShowPointsOnly}
+                        />
+                        <ResourceComparisonChart
+                          title="Network I/O"
+                          data={host.visibleMachinePoints}
+                          lines={[
+                            { dataKey: 'networkInBytes_A', name: 'In (A)', color: '#16a34a' },
+                            {
+                              dataKey: 'networkInBytes_B',
+                              name: 'In (B)',
+                              color: '#0d9488',
+                              dashPattern: '10 4',
+                            },
+                            { dataKey: 'networkOutBytes_A', name: 'Out (A)', color: '#f97316' },
+                            {
+                              dataKey: 'networkOutBytes_B',
+                              name: 'Out (B)',
+                              color: '#d97706',
+                              dashPattern: '10 4',
+                            },
+                          ]}
+                          yAxisDomain={host.machineNetworkDomain}
+                          yAxisFormatter={(v) => formatBytes(v)}
+                          tooltipFormatter={compByteTooltipFormatter}
+                          showPointsOnly={resourceShowPointsOnly}
+                        />
+                        <ResourceComparisonChart
+                          title="Block I/O"
+                          data={host.visibleMachinePoints}
+                          lines={[
+                            { dataKey: 'blockInBytes_A', name: 'In (A)', color: '#06b6d4' },
+                            {
+                              dataKey: 'blockInBytes_B',
+                              name: 'In (B)',
+                              color: '#0ea5e9',
+                              dashPattern: '10 4',
+                            },
+                            { dataKey: 'blockOutBytes_A', name: 'Out (A)', color: '#d97706' },
+                            {
+                              dataKey: 'blockOutBytes_B',
+                              name: 'Out (B)',
+                              color: '#ca8a04',
+                              dashPattern: '10 4',
+                            },
+                          ]}
+                          yAxisDomain={host.machineBlockDomain}
+                          yAxisFormatter={(v) => formatBytes(v)}
+                          tooltipFormatter={compByteTooltipFormatter}
+                          showPointsOnly={resourceShowPointsOnly}
+                        />
+                      </div>
+                    </div>
+
+                    <div className="run-comparison-host-container-section">
+                      <h4>Containers</h4>
+                      {host.services.length === 0 ? (
+                        <p className="run-results-placeholder">
+                          No containers recorded for this host.
+                        </p>
+                      ) : (
+                        <>
+                          <div className="run-results-service-selector">
+                            <button
+                              type="button"
+                              className="shell-alert-dismiss run-results-service-pill"
+                              onClick={() =>
+                                handleSelectAllCompServices(
+                                  host.hostKey,
+                                  host.services.map((s) => s.serviceKey),
+                                )
+                              }
+                            >
+                              Select all
+                            </button>
+                            <button
+                              type="button"
+                              className="shell-alert-dismiss run-results-service-pill"
+                              onClick={() => handleSelectNoCompServices(host.hostKey)}
+                            >
+                              Select none
+                            </button>
+                            {host.services.map((svc) => {
+                              const isSelected = host.selectedServiceKeys.has(svc.serviceKey)
+                              const badge = !svc.hasA ? ' (B only)' : !svc.hasB ? ' (A only)' : ''
+                              return (
+                                <button
+                                  key={svc.serviceKey}
+                                  type="button"
+                                  aria-pressed={isSelected}
+                                  className={`shell-alert-dismiss run-results-service-pill${isSelected ? ' is-selected' : ''}`}
+                                  onClick={() =>
+                                    handleToggleCompService(host.hostKey, svc.serviceKey)
+                                  }
+                                >
+                                  {svc.serviceName}{badge}
+                                </button>
+                              )
+                            })}
+                          </div>
+                          {host.selectedServiceKeys.size === 0 ? (
+                            <p className="run-results-placeholder">No services selected.</p>
+                          ) : (
+                            <>
+                              {host.services
+                                .filter((s) => host.selectedServiceKeys.has(s.serviceKey))
+                                .map((svc) => (
+                                  <div key={svc.serviceKey} className="run-comparison-service-section">
+                                    <h5 className="run-comparison-service-name">
+                                      {svc.serviceName}
+                                      {!svc.hasA && (
+                                        <span className="run-comparison-host-badge">Only in Run B</span>
+                                      )}
+                                      {!svc.hasB && (
+                                        <span className="run-comparison-host-badge">Only in Run A</span>
+                                      )}
+                                    </h5>
+                                    <div className="run-results-resource-grid">
+                                      <ResourceComparisonChart
+                                        title="CPU %"
+                                        data={svc.visiblePoints}
+                                        lines={[
+                                          {
+                                            dataKey: 'cpuPercentage_A',
+                                            name: 'CPU % (A)',
+                                            color: '#2563eb',
+                                          },
+                                          {
+                                            dataKey: 'cpuPercentage_B',
+                                            name: 'CPU % (B)',
+                                            color: '#dc2626',
+                                            dashPattern: '10 4',
+                                          },
+                                        ]}
+                                        yAxisDomain={svc.cpuDomain}
+                                        yAxisFormatter={(v) => `${Math.round(v)}%`}
+                                        tooltipFormatter={compCpuTooltipFormatter}
+                                        showPointsOnly={resourceShowPointsOnly}
+                                      />
+                                      <ResourceComparisonChart
+                                        title="Memory"
+                                        data={svc.visiblePoints}
+                                        lines={[
+                                          {
+                                            dataKey: 'memoryUsageBytes_A',
+                                            name: 'Usage (A)',
+                                            color: '#8b5cf6',
+                                          },
+                                          {
+                                            dataKey: 'memoryUsageBytes_B',
+                                            name: 'Usage (B)',
+                                            color: '#d946ef',
+                                            dashPattern: '10 4',
+                                          },
+                                        ]}
+                                        yAxisDomain={svc.memoryDomain}
+                                        yAxisFormatter={(v) => formatBytes(v)}
+                                        tooltipFormatter={compByteTooltipFormatter}
+                                        showPointsOnly={resourceShowPointsOnly}
+                                      />
+                                      <ResourceComparisonChart
+                                        title="Network I/O"
+                                        data={svc.visiblePoints}
+                                        lines={[
+                                          {
+                                            dataKey: 'networkInBytes_A',
+                                            name: 'In (A)',
+                                            color: '#16a34a',
+                                          },
+                                          {
+                                            dataKey: 'networkInBytes_B',
+                                            name: 'In (B)',
+                                            color: '#0d9488',
+                                            dashPattern: '10 4',
+                                          },
+                                          {
+                                            dataKey: 'networkOutBytes_A',
+                                            name: 'Out (A)',
+                                            color: '#f97316',
+                                          },
+                                          {
+                                            dataKey: 'networkOutBytes_B',
+                                            name: 'Out (B)',
+                                            color: '#d97706',
+                                            dashPattern: '10 4',
+                                          },
+                                        ]}
+                                        yAxisDomain={svc.networkDomain}
+                                        yAxisFormatter={(v) => formatBytes(v)}
+                                        tooltipFormatter={compByteTooltipFormatter}
+                                        showPointsOnly={resourceShowPointsOnly}
+                                      />
+                                      <ResourceComparisonChart
+                                        title="Block I/O"
+                                        data={svc.visiblePoints}
+                                        lines={[
+                                          {
+                                            dataKey: 'blockInBytes_A',
+                                            name: 'In (A)',
+                                            color: '#06b6d4',
+                                          },
+                                          {
+                                            dataKey: 'blockInBytes_B',
+                                            name: 'In (B)',
+                                            color: '#0ea5e9',
+                                            dashPattern: '10 4',
+                                          },
+                                          {
+                                            dataKey: 'blockOutBytes_A',
+                                            name: 'Out (A)',
+                                            color: '#d97706',
+                                          },
+                                          {
+                                            dataKey: 'blockOutBytes_B',
+                                            name: 'Out (B)',
+                                            color: '#ca8a04',
+                                            dashPattern: '10 4',
+                                          },
+                                        ]}
+                                        yAxisDomain={svc.blockDomain}
+                                        yAxisFormatter={(v) => formatBytes(v)}
+                                        tooltipFormatter={compByteTooltipFormatter}
+                                        showPointsOnly={resourceShowPointsOnly}
+                                      />
+                                    </div>
+                                  </div>
+                                ))}
+                            </>
+                          )}
+                        </>
+                      )}
+                    </div>
+                  </details>
+                )
+              })}
+            </>
           )}
         </section>
       </AsyncStateView>

--- a/src/features/benchmarks/BenchmarkRunComparisonPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunComparisonPage.tsx
@@ -375,8 +375,10 @@ function ResourceComparisonChart({
   if (data.length === 0) {
     return (
       <div className="run-results-resource-chart-wrap">
-        <h4 className="run-results-resource-chart-title">{title}</h4>
-        {summaryContent}
+        <div className="run-comparison-chart-header">
+          <h4 className="run-results-resource-chart-title">{title}</h4>
+          {summaryContent}
+        </div>
         <p className="run-results-placeholder">No data</p>
       </div>
     )
@@ -384,8 +386,10 @@ function ResourceComparisonChart({
 
   return (
     <div className="run-results-resource-chart-wrap">
-      <h4 className="run-results-resource-chart-title">{title}</h4>
-      {summaryContent}
+      <div className="run-comparison-chart-header">
+        <h4 className="run-results-resource-chart-title">{title}</h4>
+        {summaryContent}
+      </div>
       <ResponsiveContainer width="100%" height={200}>
         <LineChart data={data} margin={{ top: 4, right: 8, left: 0, bottom: 4 }}>
           <CartesianGrid stroke="#d9e2ef" strokeDasharray="3 3" />
@@ -458,9 +462,6 @@ export function BenchmarkRunComparisonPage() {
   const [resourceAxisScaleMode, setResourceAxisScaleMode] = useState<AxisScaleMode>('auto')
   const [resourceChartRenderMode, setResourceChartRenderMode] = useState<ChartRenderMode>('line')
   const [resourceSmoothingLevel, setResourceSmoothingLevel] = useState(0)
-  const [selectedCompServiceKeysByHost, setSelectedCompServiceKeysByHost] = useState<
-    Record<string, Set<string>>
-  >({})
 
   const environmentLabel = (environmentName ?? environmentId).trim() || 'n/a'
   const benchmarkLabel = (benchmarkName ?? benchmarkId).trim() || 'n/a'
@@ -634,10 +635,6 @@ export function BenchmarkRunComparisonPage() {
       comparisonData.derivedB,
     )
     return matched.map((host) => {
-      const selectedServiceKeys =
-        selectedCompServiceKeysByHost[host.hostKey] ??
-        new Set(host.services.map((s) => s.serviceKey))
-
       const smoothedMachinePoints = applyResourceComparisonSlidingAverage(
         host.baseComparisonPoints,
         resourceCompSmoothingWindowSize,
@@ -730,7 +727,6 @@ export function BenchmarkRunComparisonPage() {
         derivedB: host.derivedB,
         hasMemoryLimitA: host.hasMemoryLimitA,
         hasMemoryLimitB: host.hasMemoryLimitB,
-        selectedServiceKeys,
         visibleMachinePoints,
         machineCpuDomain,
         machineMemoryDomain,
@@ -744,52 +740,7 @@ export function BenchmarkRunComparisonPage() {
     resourceAxisScaleMode,
     resourceBrushElapsedRange,
     resourceCompSmoothingWindowSize,
-    selectedCompServiceKeysByHost,
   ])
-
-  useEffect(() => {
-    if (!comparisonData) {
-      setSelectedCompServiceKeysByHost({})
-      return
-    }
-    const matched = matchHosts(
-      comparisonData.rawA,
-      comparisonData.rawB,
-      comparisonData.derivedA,
-      comparisonData.derivedB,
-    )
-    const initial: Record<string, Set<string>> = {}
-    for (const host of matched) {
-      initial[host.hostKey] = new Set(host.services.map((s) => s.serviceKey))
-    }
-    setSelectedCompServiceKeysByHost(initial)
-  }, [comparisonData])
-
-  const handleToggleCompService = (hostKey: string, serviceKey: string) => {
-    setSelectedCompServiceKeysByHost((current) => {
-      const hostSet = new Set(current[hostKey] ?? [])
-      if (hostSet.has(serviceKey)) {
-        hostSet.delete(serviceKey)
-      } else {
-        hostSet.add(serviceKey)
-      }
-      return { ...current, [hostKey]: hostSet }
-    })
-  }
-
-  const handleSelectAllCompServices = (hostKey: string, allKeys: string[]) => {
-    setSelectedCompServiceKeysByHost((current) => ({
-      ...current,
-      [hostKey]: new Set(allKeys),
-    }))
-  }
-
-  const handleSelectNoCompServices = (hostKey: string) => {
-    setSelectedCompServiceKeysByHost((current) => ({
-      ...current,
-      [hostKey]: new Set<string>(),
-    }))
-  }
 
   const runIdAShort = runIdA.slice(0, 8)
   const runIdBShort = runIdB.slice(0, 8)
@@ -1257,26 +1208,22 @@ export function BenchmarkRunComparisonPage() {
               {processedComparisonHosts.map((host) => {
                 const resourceShowPointsOnly = resourceChartRenderMode === 'points'
                 const memoryLines: ResourceCompLineConfig[] = [
-                  { dataKey: 'memoryUsageBytes_A', name: 'Usage (A)', color: '#8b5cf6' },
-                  {
-                    dataKey: 'memoryUsageBytes_B',
-                    name: 'Usage (B)',
-                    color: '#d946ef',
-                    dashPattern: '10 4',
-                  },
+                  { dataKey: 'memoryUsageBytes_A', name: 'Usage (A)', color: '#2563eb' },
+                  { dataKey: 'memoryUsageBytes_B', name: 'Usage (B)', color: '#dc2626' },
                 ]
                 if (host.hasMemoryLimitA) {
                   memoryLines.push({
                     dataKey: 'memoryLimitBytes_A',
                     name: 'Limit (A)',
-                    color: '#94a3b8',
+                    color: '#93c5fd',
+                    dashPattern: '10 4',
                   })
                 }
                 if (host.hasMemoryLimitB) {
                   memoryLines.push({
                     dataKey: 'memoryLimitBytes_B',
                     name: 'Limit (B)',
-                    color: '#64748b',
+                    color: '#fca5a5',
                     dashPattern: '10 4',
                   })
                 }
@@ -1308,12 +1255,7 @@ export function BenchmarkRunComparisonPage() {
                           data={host.visibleMachinePoints}
                           lines={[
                             { dataKey: 'cpuPercentage_A', name: 'CPU % (A)', color: '#2563eb' },
-                            {
-                              dataKey: 'cpuPercentage_B',
-                              name: 'CPU % (B)',
-                              color: '#dc2626',
-                              dashPattern: '10 4',
-                            },
+                            { dataKey: 'cpuPercentage_B', name: 'CPU % (B)', color: '#dc2626' },
                           ]}
                           yAxisDomain={host.machineCpuDomain}
                           yAxisFormatter={(v) => `${Math.round(v)}%`}
@@ -1342,18 +1284,18 @@ export function BenchmarkRunComparisonPage() {
                           title="Network I/O"
                           data={host.visibleMachinePoints}
                           lines={[
-                            { dataKey: 'networkInBytes_A', name: 'In (A)', color: '#16a34a' },
+                            { dataKey: 'networkOutBytes_A', name: 'Out (A)', color: '#2563eb' },
+                            { dataKey: 'networkOutBytes_B', name: 'Out (B)', color: '#dc2626' },
+                            {
+                              dataKey: 'networkInBytes_A',
+                              name: 'In (A)',
+                              color: '#2563eb',
+                              dashPattern: '10 4',
+                            },
                             {
                               dataKey: 'networkInBytes_B',
                               name: 'In (B)',
-                              color: '#0d9488',
-                              dashPattern: '10 4',
-                            },
-                            { dataKey: 'networkOutBytes_A', name: 'Out (A)', color: '#f97316' },
-                            {
-                              dataKey: 'networkOutBytes_B',
-                              name: 'Out (B)',
-                              color: '#d97706',
+                              color: '#dc2626',
                               dashPattern: '10 4',
                             },
                           ]}
@@ -1371,18 +1313,18 @@ export function BenchmarkRunComparisonPage() {
                           title="Block I/O"
                           data={host.visibleMachinePoints}
                           lines={[
-                            { dataKey: 'blockInBytes_A', name: 'In (A)', color: '#06b6d4' },
+                            { dataKey: 'blockOutBytes_A', name: 'Out (A)', color: '#2563eb' },
+                            { dataKey: 'blockOutBytes_B', name: 'Out (B)', color: '#dc2626' },
+                            {
+                              dataKey: 'blockInBytes_A',
+                              name: 'In (A)',
+                              color: '#2563eb',
+                              dashPattern: '10 4',
+                            },
                             {
                               dataKey: 'blockInBytes_B',
                               name: 'In (B)',
-                              color: '#0ea5e9',
-                              dashPattern: '10 4',
-                            },
-                            { dataKey: 'blockOutBytes_A', name: 'Out (A)', color: '#d97706' },
-                            {
-                              dataKey: 'blockOutBytes_B',
-                              name: 'Out (B)',
-                              color: '#ca8a04',
+                              color: '#dc2626',
                               dashPattern: '10 4',
                             },
                           ]}
@@ -1407,51 +1349,7 @@ export function BenchmarkRunComparisonPage() {
                         </p>
                       ) : (
                         <>
-                          <div className="run-results-service-selector">
-                            <button
-                              type="button"
-                              className="shell-alert-dismiss run-results-service-pill"
-                              onClick={() =>
-                                handleSelectAllCompServices(
-                                  host.hostKey,
-                                  host.services.map((s) => s.serviceKey),
-                                )
-                              }
-                            >
-                              Select all
-                            </button>
-                            <button
-                              type="button"
-                              className="shell-alert-dismiss run-results-service-pill"
-                              onClick={() => handleSelectNoCompServices(host.hostKey)}
-                            >
-                              Select none
-                            </button>
-                            {host.services.map((svc) => {
-                              const isSelected = host.selectedServiceKeys.has(svc.serviceKey)
-                              const badge = !svc.hasA ? ' (B only)' : !svc.hasB ? ' (A only)' : ''
-                              return (
-                                <button
-                                  key={svc.serviceKey}
-                                  type="button"
-                                  aria-pressed={isSelected}
-                                  className={`shell-alert-dismiss run-results-service-pill${isSelected ? ' is-selected' : ''}`}
-                                  onClick={() =>
-                                    handleToggleCompService(host.hostKey, svc.serviceKey)
-                                  }
-                                >
-                                  {svc.serviceName}{badge}
-                                </button>
-                              )
-                            })}
-                          </div>
-                          {host.selectedServiceKeys.size === 0 ? (
-                            <p className="run-results-placeholder">No services selected.</p>
-                          ) : (
-                            <>
-                              {host.services
-                                .filter((s) => host.selectedServiceKeys.has(s.serviceKey))
-                                .map((svc) => (
+                          {host.services.map((svc) => (
                                   <details key={svc.serviceKey} className="run-comparison-service-section">
                                     <summary className="run-comparison-service-name">
                                       {svc.serviceName}
@@ -1467,17 +1365,8 @@ export function BenchmarkRunComparisonPage() {
                                         title="CPU %"
                                         data={svc.visiblePoints}
                                         lines={[
-                                          {
-                                            dataKey: 'cpuPercentage_A',
-                                            name: 'CPU % (A)',
-                                            color: '#2563eb',
-                                          },
-                                          {
-                                            dataKey: 'cpuPercentage_B',
-                                            name: 'CPU % (B)',
-                                            color: '#dc2626',
-                                            dashPattern: '10 4',
-                                          },
+                                          { dataKey: 'cpuPercentage_A', name: 'CPU % (A)', color: '#2563eb' },
+                                          { dataKey: 'cpuPercentage_B', name: 'CPU % (B)', color: '#dc2626' },
                                         ]}
                                         yAxisDomain={svc.cpuDomain}
                                         yAxisFormatter={(v) => `${Math.round(v)}%`}
@@ -1492,17 +1381,8 @@ export function BenchmarkRunComparisonPage() {
                                         title="Memory"
                                         data={svc.visiblePoints}
                                         lines={[
-                                          {
-                                            dataKey: 'memoryUsageBytes_A',
-                                            name: 'Usage (A)',
-                                            color: '#8b5cf6',
-                                          },
-                                          {
-                                            dataKey: 'memoryUsageBytes_B',
-                                            name: 'Usage (B)',
-                                            color: '#d946ef',
-                                            dashPattern: '10 4',
-                                          },
+                                          { dataKey: 'memoryUsageBytes_A', name: 'Usage (A)', color: '#2563eb' },
+                                          { dataKey: 'memoryUsageBytes_B', name: 'Usage (B)', color: '#dc2626' },
                                         ]}
                                         yAxisDomain={svc.memoryDomain}
                                         yAxisFormatter={(v) => formatBytes(v)}
@@ -1518,28 +1398,10 @@ export function BenchmarkRunComparisonPage() {
                                         title="Network I/O"
                                         data={svc.visiblePoints}
                                         lines={[
-                                          {
-                                            dataKey: 'networkInBytes_A',
-                                            name: 'In (A)',
-                                            color: '#16a34a',
-                                          },
-                                          {
-                                            dataKey: 'networkInBytes_B',
-                                            name: 'In (B)',
-                                            color: '#0d9488',
-                                            dashPattern: '10 4',
-                                          },
-                                          {
-                                            dataKey: 'networkOutBytes_A',
-                                            name: 'Out (A)',
-                                            color: '#f97316',
-                                          },
-                                          {
-                                            dataKey: 'networkOutBytes_B',
-                                            name: 'Out (B)',
-                                            color: '#d97706',
-                                            dashPattern: '10 4',
-                                          },
+                                          { dataKey: 'networkOutBytes_A', name: 'Out (A)', color: '#2563eb' },
+                                          { dataKey: 'networkOutBytes_B', name: 'Out (B)', color: '#dc2626' },
+                                          { dataKey: 'networkInBytes_A', name: 'In (A)', color: '#2563eb', dashPattern: '10 4' },
+                                          { dataKey: 'networkInBytes_B', name: 'In (B)', color: '#dc2626', dashPattern: '10 4' },
                                         ]}
                                         yAxisDomain={svc.networkDomain}
                                         yAxisFormatter={(v) => formatBytes(v)}
@@ -1555,28 +1417,10 @@ export function BenchmarkRunComparisonPage() {
                                         title="Block I/O"
                                         data={svc.visiblePoints}
                                         lines={[
-                                          {
-                                            dataKey: 'blockInBytes_A',
-                                            name: 'In (A)',
-                                            color: '#06b6d4',
-                                          },
-                                          {
-                                            dataKey: 'blockInBytes_B',
-                                            name: 'In (B)',
-                                            color: '#0ea5e9',
-                                            dashPattern: '10 4',
-                                          },
-                                          {
-                                            dataKey: 'blockOutBytes_A',
-                                            name: 'Out (A)',
-                                            color: '#d97706',
-                                          },
-                                          {
-                                            dataKey: 'blockOutBytes_B',
-                                            name: 'Out (B)',
-                                            color: '#ca8a04',
-                                            dashPattern: '10 4',
-                                          },
+                                          { dataKey: 'blockOutBytes_A', name: 'Out (A)', color: '#2563eb' },
+                                          { dataKey: 'blockOutBytes_B', name: 'Out (B)', color: '#dc2626' },
+                                          { dataKey: 'blockInBytes_A', name: 'In (A)', color: '#2563eb', dashPattern: '10 4' },
+                                          { dataKey: 'blockInBytes_B', name: 'In (B)', color: '#dc2626', dashPattern: '10 4' },
                                         ]}
                                         yAxisDomain={svc.blockDomain}
                                         yAxisFormatter={(v) => formatBytes(v)}
@@ -1591,8 +1435,6 @@ export function BenchmarkRunComparisonPage() {
                                     </div>
                                   </details>
                                 ))}
-                            </>
-                          )}
                         </>
                       )}
                     </div>

--- a/src/features/benchmarks/BenchmarkRunComparisonPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunComparisonPage.tsx
@@ -203,24 +203,8 @@ interface ResourceCompLineConfig {
   dashPattern?: string
 }
 
-function makeCompResourceTooltipFormatter(isByteMetric: boolean) {
-  return (
-    value: number | string | ReadonlyArray<number | string> | null | undefined,
-    name: number | string | undefined,
-  ): [string, string] => {
-    const label = typeof name === 'undefined' ? 'Value' : String(name)
-    const normalizedValue = Array.isArray(value) ? value[0] : value
-    if (typeof normalizedValue !== 'number' || Number.isNaN(normalizedValue)) {
-      return ['n/a', label]
-    }
-    return isByteMetric
-      ? [formatBytes(normalizedValue), label]
-      : [`${normalizedValue.toFixed(1)}%`, label]
-  }
-}
-
-const compCpuTooltipFormatter = makeCompResourceTooltipFormatter(false)
-const compByteTooltipFormatter = makeCompResourceTooltipFormatter(true)
+const compCpuValueFormatter = (v: number) => `${v.toFixed(1)}%`
+const compByteValueFormatter = (v: number) => formatBytes(v)
 
 // ---------------------------------------------------------------------------
 // Chart summary stat helpers
@@ -339,7 +323,7 @@ function ResourceComparisonChart({
   lines,
   yAxisDomain,
   yAxisFormatter,
-  tooltipFormatter,
+  valueFormatter,
   showPointsOnly,
   summaryContent,
 }: {
@@ -348,10 +332,7 @@ function ResourceComparisonChart({
   lines: ResourceCompLineConfig[]
   yAxisDomain: AxisDomain
   yAxisFormatter: (value: number) => string
-  tooltipFormatter: (
-    value: number | string | ReadonlyArray<number | string> | null | undefined,
-    name: number | string | undefined,
-  ) => [string, string]
+  valueFormatter: (value: number) => string
   showPointsOnly: boolean
   summaryContent?: React.ReactNode
 }) {
@@ -371,6 +352,46 @@ function ResourceComparisonChart({
       return next
     })
   }, [])
+
+  const renderTooltip = useCallback(
+    (props: Record<string, unknown>) => {
+      const { active, label, payload } = props as {
+        active?: boolean
+        label?: number | string
+        payload?: Array<{
+          dataKey?: string
+          name?: string
+          value?: number | null
+          color?: string
+        }>
+      }
+      if (!active || !payload || payload.length === 0) return null
+      return (
+        <div className="run-comparison-tooltip">
+          <div className="run-comparison-tooltip-label">
+            {formatElapsedTooltipLabel(label)}
+          </div>
+          {payload
+            .filter((p) => !hiddenLines.has(p.dataKey ?? ''))
+            .map((p) => (
+              <div key={p.dataKey} className="run-comparison-tooltip-row">
+                <span
+                  className="run-comparison-tooltip-swatch"
+                  style={{ background: p.color }}
+                />
+                <span className="run-comparison-tooltip-name">{p.name}</span>
+                <span className="run-comparison-tooltip-value">
+                  {typeof p.value === 'number' && !Number.isNaN(p.value)
+                    ? valueFormatter(p.value)
+                    : 'n/a'}
+                </span>
+              </div>
+            ))}
+        </div>
+      )
+    },
+    [hiddenLines, valueFormatter],
+  )
 
   if (data.length === 0) {
     return (
@@ -402,8 +423,7 @@ function ResourceComparisonChart({
           />
           <YAxis domain={yAxisDomain} tickFormatter={yAxisFormatter} width={68} />
           <Tooltip
-            formatter={tooltipFormatter}
-            labelFormatter={formatElapsedTooltipLabel}
+            content={renderTooltip}
             isAnimationActive={false}
           />
           <Legend onClick={handleLegendClick} />
@@ -1267,7 +1287,7 @@ export function BenchmarkRunComparisonPage() {
                           ]}
                           yAxisDomain={host.machineCpuDomain}
                           yAxisFormatter={(v) => `${Math.round(v)}%`}
-                          tooltipFormatter={compCpuTooltipFormatter}
+                          valueFormatter={compCpuValueFormatter}
                           showPointsOnly={resourceShowPointsOnly}
                           summaryContent={buildCpuSummary(
                             host.derivedA?.resource?.cpu,
@@ -1280,7 +1300,7 @@ export function BenchmarkRunComparisonPage() {
                           lines={memoryLines}
                           yAxisDomain={host.machineMemoryDomain}
                           yAxisFormatter={(v) => formatBytes(v)}
-                          tooltipFormatter={compByteTooltipFormatter}
+                          valueFormatter={compByteValueFormatter}
                           showPointsOnly={resourceShowPointsOnly}
                           summaryContent={buildMemorySummary(
                             host.derivedA?.resource?.memory,
@@ -1309,7 +1329,7 @@ export function BenchmarkRunComparisonPage() {
                           ]}
                           yAxisDomain={host.machineNetworkDomain}
                           yAxisFormatter={(v) => formatBytes(v)}
-                          tooltipFormatter={compByteTooltipFormatter}
+                          valueFormatter={compByteValueFormatter}
                           showPointsOnly={resourceShowPointsOnly}
                           summaryContent={buildIoSummary(
                             host.visibleMachinePoints,
@@ -1338,7 +1358,7 @@ export function BenchmarkRunComparisonPage() {
                           ]}
                           yAxisDomain={host.machineBlockDomain}
                           yAxisFormatter={(v) => formatBytes(v)}
-                          tooltipFormatter={compByteTooltipFormatter}
+                          valueFormatter={compByteValueFormatter}
                           showPointsOnly={resourceShowPointsOnly}
                           summaryContent={buildIoSummary(
                             host.visibleMachinePoints,
@@ -1378,7 +1398,7 @@ export function BenchmarkRunComparisonPage() {
                                         ]}
                                         yAxisDomain={svc.cpuDomain}
                                         yAxisFormatter={(v) => `${Math.round(v)}%`}
-                                        tooltipFormatter={compCpuTooltipFormatter}
+                                        valueFormatter={compCpuValueFormatter}
                                         showPointsOnly={resourceShowPointsOnly}
                                         summaryContent={buildCpuSummary(
                                           svc.derivedResourceA?.cpu,
@@ -1413,7 +1433,7 @@ export function BenchmarkRunComparisonPage() {
                                             lines={svcMemLines}
                                             yAxisDomain={svc.memoryDomain}
                                             yAxisFormatter={(v) => formatBytes(v)}
-                                            tooltipFormatter={compByteTooltipFormatter}
+                                            valueFormatter={compByteValueFormatter}
                                             showPointsOnly={resourceShowPointsOnly}
                                             summaryContent={buildMemorySummary(
                                               svc.derivedResourceA?.memory,
@@ -1434,7 +1454,7 @@ export function BenchmarkRunComparisonPage() {
                                         ]}
                                         yAxisDomain={svc.networkDomain}
                                         yAxisFormatter={(v) => formatBytes(v)}
-                                        tooltipFormatter={compByteTooltipFormatter}
+                                        valueFormatter={compByteValueFormatter}
                                         showPointsOnly={resourceShowPointsOnly}
                                         summaryContent={buildIoSummary(
                                           svc.visiblePoints,
@@ -1453,7 +1473,7 @@ export function BenchmarkRunComparisonPage() {
                                         ]}
                                         yAxisDomain={svc.blockDomain}
                                         yAxisFormatter={(v) => formatBytes(v)}
-                                        tooltipFormatter={compByteTooltipFormatter}
+                                        valueFormatter={compByteValueFormatter}
                                         showPointsOnly={resourceShowPointsOnly}
                                         summaryContent={buildIoSummary(
                                           svc.visiblePoints,

--- a/src/features/benchmarks/BenchmarkRunComparisonPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunComparisonPage.tsx
@@ -12,6 +12,7 @@ import {
   YAxis,
 } from 'recharts'
 import type { DerivedHttpSummaryDTO } from '../../generated/openapi/models/DerivedHttpSummaryDTO'
+import type { DerivedResourceStatsDTO } from '../../generated/openapi/models/DerivedResourceStatsDTO'
 import { getEnvironmentDetails } from '../environments/service'
 import { AsyncStateView } from '../ui/async-state/AsyncState'
 import type { AxisDomain, AxisScaleMode } from './charting'
@@ -221,6 +222,117 @@ function makeCompResourceTooltipFormatter(isByteMetric: boolean) {
 const compCpuTooltipFormatter = makeCompResourceTooltipFormatter(false)
 const compByteTooltipFormatter = makeCompResourceTooltipFormatter(true)
 
+// ---------------------------------------------------------------------------
+// Chart summary stat helpers
+// ---------------------------------------------------------------------------
+
+function computePointStats(
+  data: object[],
+  metricKey: string,
+): { avg: number | null; max: number | null } {
+  let sum = 0
+  let count = 0
+  let max = Number.NEGATIVE_INFINITY
+  for (const point of data) {
+    const val = (point as Record<string, unknown>)[metricKey]
+    if (typeof val === 'number' && !Number.isNaN(val)) {
+      sum += val
+      count += 1
+      if (val > max) max = val
+    }
+  }
+  if (count === 0) return { avg: null, max: null }
+  return { avg: sum / count, max }
+}
+
+function fmtPct(v?: number | null): string {
+  return v != null ? `${v.toFixed(1)}%` : '—'
+}
+
+function fmtPercentile(stats?: DerivedResourceStatsDTO | null, key?: string): string {
+  const val = key ? stats?.percentiles?.[key] : undefined
+  return val != null ? `${val.toFixed(1)}%` : '—'
+}
+
+function buildCpuSummary(
+  cpuA?: DerivedResourceStatsDTO | null,
+  cpuB?: DerivedResourceStatsDTO | null,
+): React.ReactNode {
+  if (!cpuA && !cpuB) return null
+  return (
+    <div className="run-comparison-chart-summary">
+      {cpuA && (
+        <div className="run-comparison-chart-summary-row">
+          <span className="run-comparison-chart-summary-label run-comparison-label-a">A:</span>
+          <span>Avg {fmtPct(cpuA.avg)} · Max {fmtPct(cpuA.max)} · p75 {fmtPercentile(cpuA, 'p75')} · p90 {fmtPercentile(cpuA, 'p90')} · p95 {fmtPercentile(cpuA, 'p95')}</span>
+        </div>
+      )}
+      {cpuB && (
+        <div className="run-comparison-chart-summary-row">
+          <span className="run-comparison-chart-summary-label run-comparison-label-b">B:</span>
+          <span>Avg {fmtPct(cpuB.avg)} · Max {fmtPct(cpuB.max)} · p75 {fmtPercentile(cpuB, 'p75')} · p90 {fmtPercentile(cpuB, 'p90')} · p95 {fmtPercentile(cpuB, 'p95')}</span>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function buildMemorySummary(
+  memA?: DerivedResourceStatsDTO | null,
+  memB?: DerivedResourceStatsDTO | null,
+  data?: object[],
+): React.ReactNode {
+  if (!memA && !memB) return null
+  const statsA = data ? computePointStats(data, 'memoryUsageBytes_A') : { avg: null, max: null }
+  const statsB = data ? computePointStats(data, 'memoryUsageBytes_B') : { avg: null, max: null }
+  return (
+    <div className="run-comparison-chart-summary">
+      {(memA || statsA.avg != null) && (
+        <div className="run-comparison-chart-summary-row">
+          <span className="run-comparison-chart-summary-label run-comparison-label-a">A:</span>
+          <span>Avg {formatBytes(statsA.avg ?? undefined)} ({fmtPct(memA?.avg)}) · Max {formatBytes(statsA.max ?? undefined)} ({fmtPct(memA?.max)})</span>
+        </div>
+      )}
+      {(memB || statsB.avg != null) && (
+        <div className="run-comparison-chart-summary-row">
+          <span className="run-comparison-chart-summary-label run-comparison-label-b">B:</span>
+          <span>Avg {formatBytes(statsB.avg ?? undefined)} ({fmtPct(memB?.avg)}) · Max {formatBytes(statsB.max ?? undefined)} ({fmtPct(memB?.max)})</span>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function buildIoSummary(
+  data: object[],
+  inKeyA: string,
+  inKeyB: string,
+  outKeyA: string,
+  outKeyB: string,
+): React.ReactNode {
+  const inA = computePointStats(data, inKeyA)
+  const inB = computePointStats(data, inKeyB)
+  const outA = computePointStats(data, outKeyA)
+  const outB = computePointStats(data, outKeyB)
+  if (inA.avg == null && inB.avg == null && outA.avg == null && outB.avg == null) return null
+  return (
+    <div className="run-comparison-chart-summary">
+      {(inA.avg != null || outA.avg != null) && (
+        <div className="run-comparison-chart-summary-row">
+          <span className="run-comparison-chart-summary-label run-comparison-label-a">A:</span>
+          <span>In avg {formatBytes(inA.avg ?? undefined)} · max {formatBytes(inA.max ?? undefined)} | Out avg {formatBytes(outA.avg ?? undefined)} · max {formatBytes(outA.max ?? undefined)}</span>
+        </div>
+      )}
+      {(inB.avg != null || outB.avg != null) && (
+        <div className="run-comparison-chart-summary-row">
+          <span className="run-comparison-chart-summary-label run-comparison-label-b">B:</span>
+          <span>In avg {formatBytes(inB.avg ?? undefined)} · max {formatBytes(inB.max ?? undefined)} | Out avg {formatBytes(outB.avg ?? undefined)} · max {formatBytes(outB.max ?? undefined)}</span>
+        </div>
+      )}
+    </div>
+  )
+}
+
 function ResourceComparisonChart({
   title,
   data,
@@ -229,6 +341,7 @@ function ResourceComparisonChart({
   yAxisFormatter,
   tooltipFormatter,
   showPointsOnly,
+  summaryContent,
 }: {
   title: string
   data: object[]
@@ -240,6 +353,7 @@ function ResourceComparisonChart({
     name: number | string | undefined,
   ) => [string, string]
   showPointsOnly: boolean
+  summaryContent?: React.ReactNode
 }) {
   const [hiddenLines, setHiddenLines] = useState<Set<string>>(new Set())
 
@@ -262,6 +376,7 @@ function ResourceComparisonChart({
     return (
       <div className="run-results-resource-chart-wrap">
         <h4 className="run-results-resource-chart-title">{title}</h4>
+        {summaryContent}
         <p className="run-results-placeholder">No data</p>
       </div>
     )
@@ -270,6 +385,7 @@ function ResourceComparisonChart({
   return (
     <div className="run-results-resource-chart-wrap">
       <h4 className="run-results-resource-chart-title">{title}</h4>
+      {summaryContent}
       <ResponsiveContainer width="100%" height={200}>
         <LineChart data={data} margin={{ top: 4, right: 8, left: 0, bottom: 4 }}>
           <CartesianGrid stroke="#d9e2ef" strokeDasharray="3 3" />
@@ -579,6 +695,8 @@ export function BenchmarkRunComparisonPage() {
           serviceName: svc.serviceName,
           hasA: svc.hasA,
           hasB: svc.hasB,
+          derivedResourceA: svc.derivedResourceA,
+          derivedResourceB: svc.derivedResourceB,
           visiblePoints: visibleSvcPoints,
           cpuDomain: resolveResourceComparisonYAxisDomain(
             visibleSvcPoints,
@@ -1201,6 +1319,10 @@ export function BenchmarkRunComparisonPage() {
                           yAxisFormatter={(v) => `${Math.round(v)}%`}
                           tooltipFormatter={compCpuTooltipFormatter}
                           showPointsOnly={resourceShowPointsOnly}
+                          summaryContent={buildCpuSummary(
+                            host.derivedA?.resource?.cpu,
+                            host.derivedB?.resource?.cpu,
+                          )}
                         />
                         <ResourceComparisonChart
                           title="Memory"
@@ -1210,6 +1332,11 @@ export function BenchmarkRunComparisonPage() {
                           yAxisFormatter={(v) => formatBytes(v)}
                           tooltipFormatter={compByteTooltipFormatter}
                           showPointsOnly={resourceShowPointsOnly}
+                          summaryContent={buildMemorySummary(
+                            host.derivedA?.resource?.memory,
+                            host.derivedB?.resource?.memory,
+                            host.visibleMachinePoints,
+                          )}
                         />
                         <ResourceComparisonChart
                           title="Network I/O"
@@ -1234,6 +1361,11 @@ export function BenchmarkRunComparisonPage() {
                           yAxisFormatter={(v) => formatBytes(v)}
                           tooltipFormatter={compByteTooltipFormatter}
                           showPointsOnly={resourceShowPointsOnly}
+                          summaryContent={buildIoSummary(
+                            host.visibleMachinePoints,
+                            'networkInBytes_A', 'networkInBytes_B',
+                            'networkOutBytes_A', 'networkOutBytes_B',
+                          )}
                         />
                         <ResourceComparisonChart
                           title="Block I/O"
@@ -1258,6 +1390,11 @@ export function BenchmarkRunComparisonPage() {
                           yAxisFormatter={(v) => formatBytes(v)}
                           tooltipFormatter={compByteTooltipFormatter}
                           showPointsOnly={resourceShowPointsOnly}
+                          summaryContent={buildIoSummary(
+                            host.visibleMachinePoints,
+                            'blockInBytes_A', 'blockInBytes_B',
+                            'blockOutBytes_A', 'blockOutBytes_B',
+                          )}
                         />
                       </div>
                     </div>
@@ -1315,7 +1452,7 @@ export function BenchmarkRunComparisonPage() {
                               {host.services
                                 .filter((s) => host.selectedServiceKeys.has(s.serviceKey))
                                 .map((svc) => (
-                                  <details key={svc.serviceKey} className="run-comparison-service-section" open>
+                                  <details key={svc.serviceKey} className="run-comparison-service-section">
                                     <summary className="run-comparison-service-name">
                                       {svc.serviceName}
                                       {!svc.hasA && (
@@ -1346,6 +1483,10 @@ export function BenchmarkRunComparisonPage() {
                                         yAxisFormatter={(v) => `${Math.round(v)}%`}
                                         tooltipFormatter={compCpuTooltipFormatter}
                                         showPointsOnly={resourceShowPointsOnly}
+                                        summaryContent={buildCpuSummary(
+                                          svc.derivedResourceA?.cpu,
+                                          svc.derivedResourceB?.cpu,
+                                        )}
                                       />
                                       <ResourceComparisonChart
                                         title="Memory"
@@ -1367,6 +1508,11 @@ export function BenchmarkRunComparisonPage() {
                                         yAxisFormatter={(v) => formatBytes(v)}
                                         tooltipFormatter={compByteTooltipFormatter}
                                         showPointsOnly={resourceShowPointsOnly}
+                                        summaryContent={buildMemorySummary(
+                                          svc.derivedResourceA?.memory,
+                                          svc.derivedResourceB?.memory,
+                                          svc.visiblePoints,
+                                        )}
                                       />
                                       <ResourceComparisonChart
                                         title="Network I/O"
@@ -1399,6 +1545,11 @@ export function BenchmarkRunComparisonPage() {
                                         yAxisFormatter={(v) => formatBytes(v)}
                                         tooltipFormatter={compByteTooltipFormatter}
                                         showPointsOnly={resourceShowPointsOnly}
+                                        summaryContent={buildIoSummary(
+                                          svc.visiblePoints,
+                                          'networkInBytes_A', 'networkInBytes_B',
+                                          'networkOutBytes_A', 'networkOutBytes_B',
+                                        )}
                                       />
                                       <ResourceComparisonChart
                                         title="Block I/O"
@@ -1431,6 +1582,11 @@ export function BenchmarkRunComparisonPage() {
                                         yAxisFormatter={(v) => formatBytes(v)}
                                         tooltipFormatter={compByteTooltipFormatter}
                                         showPointsOnly={resourceShowPointsOnly}
+                                        summaryContent={buildIoSummary(
+                                          svc.visiblePoints,
+                                          'blockInBytes_A', 'blockInBytes_B',
+                                          'blockOutBytes_A', 'blockOutBytes_B',
+                                        )}
                                       />
                                     </div>
                                   </details>

--- a/src/features/benchmarks/resourceComparisonCharting.ts
+++ b/src/features/benchmarks/resourceComparisonCharting.ts
@@ -1,6 +1,7 @@
 import type { BenchmarkRunDerivedDTO } from '../../generated/openapi/models/BenchmarkRunDerivedDTO'
 import type { BenchmarkRunRawDTO } from '../../generated/openapi/models/BenchmarkRunRawDTO'
 import type { DerivedHostSummaryDTO } from '../../generated/openapi/models/DerivedHostSummaryDTO'
+import type { DerivedResourceSummaryDTO } from '../../generated/openapi/models/DerivedResourceSummaryDTO'
 import type { RawResourceDataPointDTO } from '../../generated/openapi/models/RawResourceDataPointDTO'
 import type { AxisDomain, AxisScaleMode } from './charting'
 import { normalizeResourceDataPoints } from './resourceCharting'
@@ -35,6 +36,8 @@ export interface MatchedServiceComparison {
   serviceName: string
   hasA: boolean
   hasB: boolean
+  derivedResourceA: DerivedResourceSummaryDTO | null
+  derivedResourceB: DerivedResourceSummaryDTO | null
   baseComparisonPoints: ResourceComparisonPoint[]
 }
 
@@ -242,11 +245,21 @@ export function matchHosts(
     for (const serviceKey of allServiceKeys) {
       const svcA = serviceMapA.get(serviceKey)
       const svcB = serviceMapB.get(serviceKey)
+      const derivedSvcA =
+        (derivedHostA?.services ?? []).find(
+          (s) => (s.serviceName ?? s.serviceId) === serviceKey,
+        ) ?? null
+      const derivedSvcB =
+        (derivedHostB?.services ?? []).find(
+          (s) => (s.serviceName ?? s.serviceId) === serviceKey,
+        ) ?? null
       services.push({
         serviceKey,
         serviceName: serviceKey,
         hasA: svcA != null,
         hasB: svcB != null,
+        derivedResourceA: derivedSvcA?.resource ?? null,
+        derivedResourceB: derivedSvcB?.resource ?? null,
         baseComparisonPoints: mergeResourceComparisonByElapsed(svcA?.dataPoints, svcB?.dataPoints),
       })
     }

--- a/src/features/benchmarks/resourceComparisonCharting.ts
+++ b/src/features/benchmarks/resourceComparisonCharting.ts
@@ -1,0 +1,350 @@
+import type { BenchmarkRunDerivedDTO } from '../../generated/openapi/models/BenchmarkRunDerivedDTO'
+import type { BenchmarkRunRawDTO } from '../../generated/openapi/models/BenchmarkRunRawDTO'
+import type { DerivedHostSummaryDTO } from '../../generated/openapi/models/DerivedHostSummaryDTO'
+import type { RawResourceDataPointDTO } from '../../generated/openapi/models/RawResourceDataPointDTO'
+import type { AxisDomain, AxisScaleMode } from './charting'
+import { normalizeResourceDataPoints } from './resourceCharting'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ResourceComparisonPoint {
+  elapsedMs: number
+  elapsedLabel: string
+  cpuPercentage_A: number | null
+  cpuPercentage_B: number | null
+  memoryUsageBytes_A: number | null
+  memoryUsageBytes_B: number | null
+  memoryLimitBytes_A: number | null
+  memoryLimitBytes_B: number | null
+  networkInBytes_A: number | null
+  networkInBytes_B: number | null
+  networkOutBytes_A: number | null
+  networkOutBytes_B: number | null
+  blockInBytes_A: number | null
+  blockInBytes_B: number | null
+  blockOutBytes_A: number | null
+  blockOutBytes_B: number | null
+}
+
+export type ResourceComparisonMetricKey = keyof Omit<ResourceComparisonPoint, 'elapsedMs' | 'elapsedLabel'>
+
+export interface MatchedServiceComparison {
+  serviceKey: string
+  serviceName: string
+  hasA: boolean
+  hasB: boolean
+  baseComparisonPoints: ResourceComparisonPoint[]
+}
+
+export interface MatchedHostComparison {
+  hostKey: string
+  hostName: string
+  hasA: boolean
+  hasB: boolean
+  derivedA: DerivedHostSummaryDTO | null
+  derivedB: DerivedHostSummaryDTO | null
+  hasMemoryLimitA: boolean
+  hasMemoryLimitB: boolean
+  baseComparisonPoints: ResourceComparisonPoint[]
+  services: MatchedServiceComparison[]
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const ALL_RESOURCE_COMPARISON_METRICS: ReadonlyArray<ResourceComparisonMetricKey> = [
+  'cpuPercentage_A',
+  'cpuPercentage_B',
+  'memoryUsageBytes_A',
+  'memoryUsageBytes_B',
+  'memoryLimitBytes_A',
+  'memoryLimitBytes_B',
+  'networkInBytes_A',
+  'networkInBytes_B',
+  'networkOutBytes_A',
+  'networkOutBytes_B',
+  'blockInBytes_A',
+  'blockInBytes_B',
+  'blockOutBytes_A',
+  'blockOutBytes_B',
+]
+
+const AUTO_DOMAIN: AxisDomain = ['auto', 'auto']
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatElapsedLabel(elapsedMs: number): string {
+  const totalSeconds = Math.floor(elapsedMs / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  if (minutes > 0) {
+    return `${minutes}m ${seconds.toString().padStart(2, '0')}s`
+  }
+  return `${seconds}s`
+}
+
+function withTightPadding(min: number, max: number): AxisDomain {
+  if (min === max) {
+    const padding = Math.max(Math.abs(min) * 0.1, 1)
+    const paddedMin = min - padding
+    return [min >= 0 ? Math.max(0, paddedMin) : paddedMin, max + padding]
+  }
+  const padding = Math.max((max - min) * 0.08, 1)
+  const paddedMin = min - padding
+  return [min >= 0 ? Math.max(0, paddedMin) : paddedMin, max + padding]
+}
+
+// ---------------------------------------------------------------------------
+// Merge
+// ---------------------------------------------------------------------------
+
+export function mergeResourceComparisonByElapsed(
+  rawDataPointsA: ReadonlyArray<RawResourceDataPointDTO> | undefined,
+  rawDataPointsB: ReadonlyArray<RawResourceDataPointDTO> | undefined,
+): Array<ResourceComparisonPoint> {
+  const normalizedA = normalizeResourceDataPoints(rawDataPointsA ?? [])
+  const normalizedB = normalizeResourceDataPoints(rawDataPointsB ?? [])
+
+  const baseA = normalizedA.length > 0 ? normalizedA[0].timestampMs : 0
+  const baseB = normalizedB.length > 0 ? normalizedB[0].timestampMs : 0
+
+  const merged = new Map<number, ResourceComparisonPoint>()
+
+  for (const point of normalizedA) {
+    const elapsedMs = point.timestampMs - baseA
+    merged.set(elapsedMs, {
+      elapsedMs,
+      elapsedLabel: formatElapsedLabel(elapsedMs),
+      cpuPercentage_A: point.cpuPercentage,
+      cpuPercentage_B: null,
+      memoryUsageBytes_A: point.memoryUsageBytes,
+      memoryUsageBytes_B: null,
+      memoryLimitBytes_A: point.memoryLimitBytes,
+      memoryLimitBytes_B: null,
+      networkInBytes_A: point.networkInBytes,
+      networkInBytes_B: null,
+      networkOutBytes_A: point.networkOutBytes,
+      networkOutBytes_B: null,
+      blockInBytes_A: point.blockInBytes,
+      blockInBytes_B: null,
+      blockOutBytes_A: point.blockOutBytes,
+      blockOutBytes_B: null,
+    })
+  }
+
+  for (const point of normalizedB) {
+    const elapsedMs = point.timestampMs - baseB
+    const existing = merged.get(elapsedMs)
+    if (existing) {
+      existing.cpuPercentage_B = point.cpuPercentage
+      existing.memoryUsageBytes_B = point.memoryUsageBytes
+      existing.memoryLimitBytes_B = point.memoryLimitBytes
+      existing.networkInBytes_B = point.networkInBytes
+      existing.networkOutBytes_B = point.networkOutBytes
+      existing.blockInBytes_B = point.blockInBytes
+      existing.blockOutBytes_B = point.blockOutBytes
+    } else {
+      merged.set(elapsedMs, {
+        elapsedMs,
+        elapsedLabel: formatElapsedLabel(elapsedMs),
+        cpuPercentage_A: null,
+        cpuPercentage_B: point.cpuPercentage,
+        memoryUsageBytes_A: null,
+        memoryUsageBytes_B: point.memoryUsageBytes,
+        memoryLimitBytes_A: null,
+        memoryLimitBytes_B: point.memoryLimitBytes,
+        networkInBytes_A: null,
+        networkInBytes_B: point.networkInBytes,
+        networkOutBytes_A: null,
+        networkOutBytes_B: point.networkOutBytes,
+        blockInBytes_A: null,
+        blockInBytes_B: point.blockInBytes,
+        blockOutBytes_A: null,
+        blockOutBytes_B: point.blockOutBytes,
+      })
+    }
+  }
+
+  return Array.from(merged.values()).sort((a, b) => a.elapsedMs - b.elapsedMs)
+}
+
+// ---------------------------------------------------------------------------
+// Host / service matching
+// ---------------------------------------------------------------------------
+
+export function matchHosts(
+  rawA: BenchmarkRunRawDTO | null,
+  rawB: BenchmarkRunRawDTO | null,
+  derivedA: BenchmarkRunDerivedDTO | null,
+  derivedB: BenchmarkRunDerivedDTO | null,
+): Array<MatchedHostComparison> {
+  const hostsA = rawA?.timeSeries?.hosts ?? []
+  const hostsB = rawB?.timeSeries?.hosts ?? []
+  const derivedHostsA = derivedA?.hosts ?? []
+  const derivedHostsB = derivedB?.hosts ?? []
+
+  type RawHost = (typeof hostsA)[number]
+  const hostMapA = new Map<string, RawHost>()
+  const hostMapB = new Map<string, RawHost>()
+
+  for (const host of hostsA) {
+    const key = host.hostName ?? host.hostId
+    if (key) hostMapA.set(key, host)
+  }
+  for (const host of hostsB) {
+    const key = host.hostName ?? host.hostId
+    if (key) hostMapB.set(key, host)
+  }
+
+  const allHostKeys = new Set<string>([...hostMapA.keys(), ...hostMapB.keys()])
+  const result: MatchedHostComparison[] = []
+
+  for (const hostKey of allHostKeys) {
+    const rawHostA = hostMapA.get(hostKey)
+    const rawHostB = hostMapB.get(hostKey)
+
+    const derivedHostA = derivedHostsA.find((h) => (h.hostName ?? h.hostId) === hostKey) ?? null
+    const derivedHostB = derivedHostsB.find((h) => (h.hostName ?? h.hostId) === hostKey) ?? null
+
+    const baseComparisonPoints = mergeResourceComparisonByElapsed(
+      rawHostA?.dataPoints,
+      rawHostB?.dataPoints,
+    )
+
+    const hasMemoryLimitA = baseComparisonPoints.some(
+      (p) => p.memoryLimitBytes_A != null && p.memoryLimitBytes_A > 0,
+    )
+    const hasMemoryLimitB = baseComparisonPoints.some(
+      (p) => p.memoryLimitBytes_B != null && p.memoryLimitBytes_B > 0,
+    )
+
+    type RawService = NonNullable<RawHost['services']>[number]
+    const serviceMapA = new Map<string, RawService>()
+    const serviceMapB = new Map<string, RawService>()
+
+    for (const svc of rawHostA?.services ?? []) {
+      const key = svc.serviceName ?? svc.serviceId
+      if (key) serviceMapA.set(key, svc)
+    }
+    for (const svc of rawHostB?.services ?? []) {
+      const key = svc.serviceName ?? svc.serviceId
+      if (key) serviceMapB.set(key, svc)
+    }
+
+    const allServiceKeys = new Set<string>([...serviceMapA.keys(), ...serviceMapB.keys()])
+    const services: MatchedServiceComparison[] = []
+
+    for (const serviceKey of allServiceKeys) {
+      const svcA = serviceMapA.get(serviceKey)
+      const svcB = serviceMapB.get(serviceKey)
+      services.push({
+        serviceKey,
+        serviceName: serviceKey,
+        hasA: svcA != null,
+        hasB: svcB != null,
+        baseComparisonPoints: mergeResourceComparisonByElapsed(svcA?.dataPoints, svcB?.dataPoints),
+      })
+    }
+
+    services.sort((a, b) => a.serviceKey.localeCompare(b.serviceKey))
+
+    result.push({
+      hostKey,
+      hostName: hostKey,
+      hasA: rawHostA != null,
+      hasB: rawHostB != null,
+      derivedA: derivedHostA,
+      derivedB: derivedHostB,
+      hasMemoryLimitA,
+      hasMemoryLimitB,
+      baseComparisonPoints,
+      services,
+    })
+  }
+
+  result.sort((a, b) => a.hostKey.localeCompare(b.hostKey))
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Smoothing
+// ---------------------------------------------------------------------------
+
+export function applyResourceComparisonSlidingAverage(
+  points: ReadonlyArray<ResourceComparisonPoint>,
+  windowSize: number,
+): Array<ResourceComparisonPoint> {
+  if (windowSize <= 1 || points.length === 0) {
+    return [...points]
+  }
+
+  const normalizedWindowSize = Math.max(Math.floor(windowSize), 1)
+  const leftWindowSize = Math.floor((normalizedWindowSize - 1) / 2)
+  const rightWindowSize = Math.ceil((normalizedWindowSize - 1) / 2)
+
+  return points.map((point, index) => {
+    const startIndex = Math.max(index - leftWindowSize, 0)
+    const endIndex = Math.min(index + rightWindowSize, points.length - 1)
+    const averaged: ResourceComparisonPoint = { ...point }
+
+    for (const metric of ALL_RESOURCE_COMPARISON_METRICS) {
+      let sum = 0
+      let count = 0
+      for (let i = startIndex; i <= endIndex; i += 1) {
+        const value = points[i][metric]
+        if (value != null && !Number.isNaN(value)) {
+          sum += value
+          count += 1
+        }
+      }
+      averaged[metric] = count > 0 ? sum / count : null
+    }
+
+    return averaged
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Y-axis domain
+// ---------------------------------------------------------------------------
+
+export function resolveResourceComparisonYAxisDomain(
+  points: ReadonlyArray<ResourceComparisonPoint>,
+  metrics: ReadonlyArray<ResourceComparisonMetricKey>,
+  mode: AxisScaleMode,
+): AxisDomain {
+  if (mode === 'auto') {
+    return AUTO_DOMAIN
+  }
+
+  let min = Number.POSITIVE_INFINITY
+  let max = Number.NEGATIVE_INFINITY
+  let hasValue = false
+
+  for (const point of points) {
+    for (const metric of metrics) {
+      const value = point[metric]
+      if (value != null && !Number.isNaN(value)) {
+        if (value < min) min = value
+        if (value > max) max = value
+        hasValue = true
+      }
+    }
+  }
+
+  if (!hasValue) {
+    return AUTO_DOMAIN
+  }
+
+  if (mode === 'from-zero') {
+    const paddedMax = max <= 0 ? 1 : max + Math.max(max * 0.05, 1)
+    return [0, paddedMax]
+  }
+
+  return withTightPadding(min, max)
+}

--- a/src/features/benchmarks/resourceComparisonCharting.ts
+++ b/src/features/benchmarks/resourceComparisonCharting.ts
@@ -213,8 +213,10 @@ export function matchHosts(
     const rawHostA = hostMapA.get(hostKey)
     const rawHostB = hostMapB.get(hostKey)
 
-    const derivedHostA = derivedHostsA.find((h) => (h.hostName ?? h.hostId) === hostKey) ?? null
-    const derivedHostB = derivedHostsB.find((h) => (h.hostName ?? h.hostId) === hostKey) ?? null
+    const derivedHostA =
+      derivedHostsA.find((h) => h.hostId === hostKey || h.hostName === hostKey) ?? null
+    const derivedHostB =
+      derivedHostsB.find((h) => h.hostId === hostKey || h.hostName === hostKey) ?? null
 
     const baseComparisonPoints = mergeResourceComparisonByElapsed(
       rawHostA?.dataPoints,
@@ -249,11 +251,11 @@ export function matchHosts(
       const svcB = serviceMapB.get(serviceKey)
       const derivedSvcA =
         (derivedHostA?.services ?? []).find(
-          (s) => (s.serviceName ?? s.serviceId) === serviceKey,
+          (s) => s.serviceId === serviceKey || s.serviceName === serviceKey,
         ) ?? null
       const derivedSvcB =
         (derivedHostB?.services ?? []).find(
-          (s) => (s.serviceName ?? s.serviceId) === serviceKey,
+          (s) => s.serviceId === serviceKey || s.serviceName === serviceKey,
         ) ?? null
       const svcPoints = mergeResourceComparisonByElapsed(svcA?.dataPoints, svcB?.dataPoints)
       const svcHasMemLimitA = svcPoints.some(

--- a/src/features/benchmarks/resourceComparisonCharting.ts
+++ b/src/features/benchmarks/resourceComparisonCharting.ts
@@ -36,6 +36,8 @@ export interface MatchedServiceComparison {
   serviceName: string
   hasA: boolean
   hasB: boolean
+  hasMemoryLimitA: boolean
+  hasMemoryLimitB: boolean
   derivedResourceA: DerivedResourceSummaryDTO | null
   derivedResourceB: DerivedResourceSummaryDTO | null
   baseComparisonPoints: ResourceComparisonPoint[]
@@ -253,14 +255,23 @@ export function matchHosts(
         (derivedHostB?.services ?? []).find(
           (s) => (s.serviceName ?? s.serviceId) === serviceKey,
         ) ?? null
+      const svcPoints = mergeResourceComparisonByElapsed(svcA?.dataPoints, svcB?.dataPoints)
+      const svcHasMemLimitA = svcPoints.some(
+        (p) => p.memoryLimitBytes_A != null && p.memoryLimitBytes_A > 0,
+      )
+      const svcHasMemLimitB = svcPoints.some(
+        (p) => p.memoryLimitBytes_B != null && p.memoryLimitBytes_B > 0,
+      )
       services.push({
         serviceKey,
         serviceName: serviceKey,
         hasA: svcA != null,
         hasB: svcB != null,
+        hasMemoryLimitA: svcHasMemLimitA,
+        hasMemoryLimitB: svcHasMemLimitB,
         derivedResourceA: derivedSvcA?.resource ?? null,
         derivedResourceB: derivedSvcB?.resource ?? null,
-        baseComparisonPoints: mergeResourceComparisonByElapsed(svcA?.dataPoints, svcB?.dataPoints),
+        baseComparisonPoints: svcPoints,
       })
     }
 


### PR DESCRIPTION
## Summary
Replaces the plain-text host resource summaries on the run comparison page with interactive A-vs-B overlay time-series charts for CPU, memory, network I/O, and block I/O — at both machine and per-service levels.

Closes #76

## Changes

### New module: `resourceComparisonCharting.ts`
- `ResourceComparisonPoint` type with `_A`/`_B` suffixed metrics
- `matchHosts()` — matches hosts and services by name across runs, flags unmatched
- `mergeResourceComparisonByElapsed()` — merges two resource time-series by elapsed time
- `applyResourceComparisonSlidingAverage()` — smoothing for comparison data
- `resolveResourceComparisonYAxisDomain()` — tight-fit Y-axis domain

### Comparison page (`BenchmarkRunComparisonPage.tsx`)
- **Chart UI**: 4 charts per host (CPU, Memory, Network I/O, Block I/O) with matching per-service charts in foldable `<details>` cards
- **Line conventions**: Color = run identity (blue=A, red=B), dash pattern = metric meaning (dashed=limit/inbound, solid=usage/outbound)
- **Summary stats**: Per-chart stats (avg, max, percentiles for CPU; bytes + %% for memory; avg/max for I/O) displayed inline with chart title on wide screens
- **Custom tooltip**: Shows all visible series values at hovered timestamp using nearest-neighbor lookup within 1%% of run length — ensures both runs are always visible
- **Controls**: Y-axis scale mode, render mode (line/points), smoothing slider — consistent with existing K6 comparison charts
- **Host/service matching**: Badges for hosts/services only in one run

### Styling (`App.css`)
- Host cards, service sections, chart headers, summary stats, custom tooltip styles