### PR TITLE
feat(ui): service picker panel on benchmark create/edit form (#79)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1439,7 +1439,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.45rem;
-  max-width: 760px;
+  max-width: 1100px;
 }
 
 .benchmark-textarea {
@@ -1465,6 +1465,158 @@
 .benchmark-form-actions .shell-alert-dismiss {
   margin-top: 0;
   min-height: 40px;
+}
+
+/* K6 instructions section: two-column layout with service picker */
+.benchmark-k6-section {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 260px;
+  gap: 1rem;
+  align-items: start;
+}
+
+.benchmark-k6-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  min-width: 0;
+}
+
+.benchmark-k6-field .benchmark-textarea {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+@media (max-width: 700px) {
+  .benchmark-k6-section {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Service picker panel */
+.benchmark-service-picker {
+  border: 1px solid #c7d4e3;
+  border-radius: 8px;
+  background: #f9fbfe;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  max-height: 340px;
+}
+
+.benchmark-service-picker-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid #c7d4e3;
+  background: #f0f5fb;
+  gap: 0.5rem;
+}
+
+.benchmark-service-picker-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #1f3347;
+}
+
+.benchmark-service-picker-loading {
+  font-size: 0.78rem;
+  color: #5a7a99;
+}
+
+.benchmark-service-picker-list {
+  list-style: none;
+  margin: 0;
+  padding: 0.3rem;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.benchmark-service-picker-list li {
+  margin: 0;
+}
+
+.benchmark-service-picker-item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
+  padding: 0.4rem 0.5rem;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  gap: 0.1rem;
+  transition: background 0.12s;
+}
+
+.benchmark-service-picker-item:hover {
+  background: #e8f0fa;
+}
+
+.benchmark-service-picker-item:active {
+  background: #d0e4f7;
+}
+
+.benchmark-service-picker-item-name {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #1a3250;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  word-break: break-all;
+}
+
+.benchmark-service-picker-item-image {
+  font-size: 0.75rem;
+  color: #5a7a99;
+  word-break: break-all;
+}
+
+.benchmark-service-picker-copied {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: #166534;
+  background: #dcfce7;
+  border-radius: 3px;
+  padding: 0 0.3rem;
+  margin-top: 0.1rem;
+}
+
+.benchmark-service-picker-empty {
+  margin: 0;
+  padding: 0.75rem;
+  font-size: 0.85rem;
+  color: #5a7a99;
+}
+
+.benchmark-service-picker-error {
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.benchmark-service-picker-error p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #b42318;
+}
+
+.benchmark-service-picker-retry {
+  align-self: flex-start;
+  font-size: 0.82rem;
+  padding: 0.2rem 0.5rem;
+  border: 1px solid #c7d4e3;
+  border-radius: 5px;
+  background: #fff;
+  cursor: pointer;
+  color: #1f3347;
+}
+
+.benchmark-service-picker-retry:hover {
+  background: #f0f5fb;
 }
 
 .async-state {

--- a/src/App.css
+++ b/src/App.css
@@ -1514,6 +1514,28 @@
   gap: 0.5rem;
 }
 
+.benchmark-service-picker-search {
+  padding: 0.4rem 0.5rem;
+  border-bottom: 1px solid #e2eaf4;
+}
+
+.benchmark-service-picker-search-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.3rem 0.5rem;
+  font-size: 0.82rem;
+  border: 1px solid #c7d4e3;
+  border-radius: 5px;
+  background: #fff;
+  color: #1f3347;
+  outline: none;
+}
+
+.benchmark-service-picker-search-input:focus {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
+}
+
 .benchmark-service-picker-title {
   font-size: 0.85rem;
   font-weight: 600;

--- a/src/features/benchmarks/BenchmarkFormPage.tsx
+++ b/src/features/benchmarks/BenchmarkFormPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type ChangeEvent, type FormEvent } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent, type FormEvent } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { AsyncStateView } from '../ui/async-state/AsyncState'
 import {
@@ -10,6 +10,7 @@ import {
   updateBenchmark,
   UpdateBenchmarkError,
 } from './service'
+import { ServicePickerPanel } from './ServicePickerPanel'
 
 interface BenchmarkFormValues {
   name: string
@@ -64,6 +65,43 @@ export function BenchmarkFormPage() {
   const [isLoading, setIsLoading] = useState(isEditMode)
   const [loadError, setLoadError] = useState<string | null>(null)
   const [retryAttempt, setRetryAttempt] = useState(0)
+
+  // K6 textarea cursor tracking for service picker insertion
+  const k6TextareaRef = useRef<HTMLTextAreaElement>(null)
+  const k6SelectionRef = useRef<{ start: number; end: number }>({ start: 0, end: 0 })
+  const k6HasFocusedRef = useRef(false)
+  const [copiedService, setCopiedService] = useState<string | null>(null)
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const handleInsertService = useCallback(
+    (serviceName: string) => {
+      if (!k6HasFocusedRef.current) {
+        void navigator.clipboard.writeText(serviceName).then(() => {
+          setCopiedService(serviceName)
+          if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current)
+          copiedTimerRef.current = setTimeout(() => setCopiedService(null), 2000)
+        })
+        return
+      }
+      const { start, end } = k6SelectionRef.current
+      setValues((prev) => {
+        const next =
+          prev.k6Instructions.slice(0, start) +
+          serviceName +
+          prev.k6Instructions.slice(end)
+        return { ...prev, k6Instructions: next }
+      })
+      setErrors((prev) => ({ ...prev, k6Instructions: undefined }))
+      setSubmitError(null)
+      const newCursor = start + serviceName.length
+      k6SelectionRef.current = { start: newCursor, end: newCursor }
+      setTimeout(() => {
+        k6TextareaRef.current?.focus()
+        k6TextareaRef.current?.setSelectionRange(newCursor, newCursor)
+      }, 0)
+    },
+    [],
+  )
 
   useEffect(() => {
     if (!isEditMode || !benchmarkId) {
@@ -287,30 +325,51 @@ export function BenchmarkFormPage() {
             </p>
           ) : null}
 
-          <label className="auth-label" htmlFor="benchmark-k6-instructions">
-            K6 instructions
-          </label>
-          <textarea
-            id="benchmark-k6-instructions"
-            className="auth-input benchmark-textarea"
-            value={values.k6Instructions}
-            onChange={handleChange('k6Instructions')}
-            aria-invalid={Boolean(errors.k6Instructions)}
-            aria-describedby={
-              errors.k6Instructions ? 'benchmark-k6-instructions-error' : undefined
-            }
-            disabled={isSubmitting}
-            rows={8}
-          />
-          {errors.k6Instructions ? (
-            <p
-              id="benchmark-k6-instructions-error"
-              className="benchmark-field-error"
-              role="alert"
-            >
-              {errors.k6Instructions}
-            </p>
-          ) : null}
+          <div className="benchmark-k6-section">
+            <div className="benchmark-k6-field">
+              <label className="auth-label" htmlFor="benchmark-k6-instructions">
+                K6 instructions
+              </label>
+              <textarea
+                id="benchmark-k6-instructions"
+                ref={k6TextareaRef}
+                className="auth-input benchmark-textarea"
+                value={values.k6Instructions}
+                onChange={handleChange('k6Instructions')}
+                onFocus={() => {
+                  k6HasFocusedRef.current = true
+                }}
+                onSelect={(e) => {
+                  const t = e.currentTarget
+                  k6SelectionRef.current = { start: t.selectionStart, end: t.selectionEnd }
+                }}
+                onKeyUp={(e) => {
+                  const t = e.currentTarget
+                  k6SelectionRef.current = { start: t.selectionStart, end: t.selectionEnd }
+                }}
+                aria-invalid={Boolean(errors.k6Instructions)}
+                aria-describedby={
+                  errors.k6Instructions ? 'benchmark-k6-instructions-error' : undefined
+                }
+                disabled={isSubmitting}
+                rows={8}
+              />
+              {errors.k6Instructions ? (
+                <p
+                  id="benchmark-k6-instructions-error"
+                  className="benchmark-field-error"
+                  role="alert"
+                >
+                  {errors.k6Instructions}
+                </p>
+              ) : null}
+            </div>
+            <ServicePickerPanel
+              environmentId={environmentId}
+              onServiceClick={handleInsertService}
+              copiedService={copiedService}
+            />
+          </div>
 
           {submitError ? (
             <p className="auth-notice auth-notice-error" role="alert">

--- a/src/features/benchmarks/BenchmarkFormPage.tsx
+++ b/src/features/benchmarks/BenchmarkFormPage.tsx
@@ -83,22 +83,14 @@ export function BenchmarkFormPage() {
         })
         return
       }
+      const textarea = k6TextareaRef.current
+      if (!textarea) return
+      // Restore focus and cursor position, then use execCommand so the
+      // insertion is recorded on the browser's native undo stack (Ctrl+Z).
       const { start, end } = k6SelectionRef.current
-      setValues((prev) => {
-        const next =
-          prev.k6Instructions.slice(0, start) +
-          serviceName +
-          prev.k6Instructions.slice(end)
-        return { ...prev, k6Instructions: next }
-      })
-      setErrors((prev) => ({ ...prev, k6Instructions: undefined }))
-      setSubmitError(null)
-      const newCursor = start + serviceName.length
-      k6SelectionRef.current = { start: newCursor, end: newCursor }
-      setTimeout(() => {
-        k6TextareaRef.current?.focus()
-        k6TextareaRef.current?.setSelectionRange(newCursor, newCursor)
-      }, 0)
+      textarea.focus()
+      textarea.setSelectionRange(start, end)
+      document.execCommand('insertText', false, serviceName)
     },
     [],
   )
@@ -344,6 +336,10 @@ export function BenchmarkFormPage() {
                   k6SelectionRef.current = { start: t.selectionStart, end: t.selectionEnd }
                 }}
                 onKeyUp={(e) => {
+                  const t = e.currentTarget
+                  k6SelectionRef.current = { start: t.selectionStart, end: t.selectionEnd }
+                }}
+                onBlur={(e) => {
                   const t = e.currentTarget
                   k6SelectionRef.current = { start: t.selectionStart, end: t.selectionEnd }
                 }}

--- a/src/features/benchmarks/BenchmarkFormPage.tsx
+++ b/src/features/benchmarks/BenchmarkFormPage.tsx
@@ -73,26 +73,56 @@ export function BenchmarkFormPage() {
   const [copiedService, setCopiedService] = useState<string | null>(null)
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
+  // Clear any pending badge timer on unmount to avoid state updates after navigation.
+  useEffect(() => {
+    return () => {
+      if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current)
+    }
+  }, [])
+
+  const showCopiedBadge = useCallback((serviceName: string) => {
+    setCopiedService(serviceName)
+    if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current)
+    copiedTimerRef.current = setTimeout(() => setCopiedService(null), 2000)
+  }, [])
+
+  const insertAtCursor = useCallback((serviceName: string) => {
+    const textarea = k6TextareaRef.current
+    if (!textarea) return
+    const { start, end } = k6SelectionRef.current
+    textarea.focus()
+    textarea.setSelectionRange(start, end)
+    // Use execCommand for native undo stack (Ctrl+Z). Fall back to state
+    // splice if the command is unavailable or returns false.
+    const inserted = document.execCommand('insertText', false, serviceName)
+    if (!inserted) {
+      const next = textarea.value.slice(0, start) + serviceName + textarea.value.slice(end)
+      setValues((prev) => ({ ...prev, k6Instructions: next }))
+      setErrors((prev) => ({ ...prev, k6Instructions: undefined }))
+      setSubmitError(null)
+      const newCursor = start + serviceName.length
+      k6SelectionRef.current = { start: newCursor, end: newCursor }
+      setTimeout(() => { textarea.setSelectionRange(newCursor, newCursor) }, 0)
+    }
+  }, [])
+
   const handleInsertService = useCallback(
     (serviceName: string) => {
       if (!k6HasFocusedRef.current) {
-        void navigator.clipboard.writeText(serviceName).then(() => {
-          setCopiedService(serviceName)
-          if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current)
-          copiedTimerRef.current = setTimeout(() => setCopiedService(null), 2000)
-        })
+        navigator.clipboard.writeText(serviceName).then(
+          () => showCopiedBadge(serviceName),
+          () => {
+            // Clipboard unavailable — fall back to inserting at position 0.
+            k6HasFocusedRef.current = true
+            k6SelectionRef.current = { start: 0, end: 0 }
+            insertAtCursor(serviceName)
+          },
+        )
         return
       }
-      const textarea = k6TextareaRef.current
-      if (!textarea) return
-      // Restore focus and cursor position, then use execCommand so the
-      // insertion is recorded on the browser's native undo stack (Ctrl+Z).
-      const { start, end } = k6SelectionRef.current
-      textarea.focus()
-      textarea.setSelectionRange(start, end)
-      document.execCommand('insertText', false, serviceName)
+      insertAtCursor(serviceName)
     },
-    [],
+    [insertAtCursor, showCopiedBadge],
   )
 
   useEffect(() => {

--- a/src/features/benchmarks/ServicePickerPanel.tsx
+++ b/src/features/benchmarks/ServicePickerPanel.tsx
@@ -21,6 +21,7 @@ export function ServicePickerPanel({
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [retryCounter, setRetryCounter] = useState(0)
+  const [searchQuery, setSearchQuery] = useState('')
 
   const fetchServices = useCallback(
     async (isActive: { value: boolean }) => {
@@ -54,12 +55,31 @@ export function ServicePickerPanel({
     }
   }, [fetchServices, retryCounter])
 
+  const filteredServices = searchQuery.trim()
+    ? services.filter((s) =>
+        s.serviceName.toLowerCase().includes(searchQuery.trim().toLowerCase()),
+      )
+    : services
+
   return (
     <aside className="benchmark-service-picker">
       <div className="benchmark-service-picker-header">
         <span className="benchmark-service-picker-title">Services</span>
         {loading && <span className="benchmark-service-picker-loading">Loading…</span>}
       </div>
+
+      {!error && (
+        <div className="benchmark-service-picker-search">
+          <input
+            type="search"
+            className="benchmark-service-picker-search-input"
+            placeholder="Filter services…"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            aria-label="Filter services"
+          />
+        </div>
+      )}
 
       {error ? (
         <div className="benchmark-service-picker-error">
@@ -74,9 +94,11 @@ export function ServicePickerPanel({
         </div>
       ) : !loading && services.length === 0 ? (
         <p className="benchmark-service-picker-empty">No services registered.</p>
+      ) : !loading && filteredServices.length === 0 ? (
+        <p className="benchmark-service-picker-empty">No services match your search.</p>
       ) : (
         <ul className="benchmark-service-picker-list" role="list">
-          {services.map((svc) => (
+          {filteredServices.map((svc) => (
             <li key={svc.id ?? svc.serviceName}>
               <button
                 type="button"

--- a/src/features/benchmarks/ServicePickerPanel.tsx
+++ b/src/features/benchmarks/ServicePickerPanel.tsx
@@ -1,0 +1,103 @@
+import { useCallback, useEffect, useState } from 'react'
+import type { ServiceDTO } from '../../generated/openapi/models/ServiceDTO'
+import { getEnvironmentServices } from '../environments/service'
+
+const POLL_INTERVAL_MS = 30_000
+
+interface ServicePickerPanelProps {
+  environmentId: string
+  /** Called when the user clicks a service entry. Parent decides insert vs clipboard. */
+  onServiceClick: (serviceName: string) => void
+  /** Service name that was most recently copied to clipboard (drives the "Copied!" badge). */
+  copiedService: string | null
+}
+
+export function ServicePickerPanel({
+  environmentId,
+  onServiceClick,
+  copiedService,
+}: ServicePickerPanelProps) {
+  const [services, setServices] = useState<ServiceDTO[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [retryCounter, setRetryCounter] = useState(0)
+
+  const fetchServices = useCallback(
+    async (isActive: { value: boolean }) => {
+      try {
+        const result = await getEnvironmentServices(environmentId)
+        if (!isActive.value) return
+        setServices(result.slice().sort((a, b) => a.serviceName.localeCompare(b.serviceName)))
+        setError(null)
+      } catch {
+        if (!isActive.value) return
+        setError('Unable to load services right now.')
+      } finally {
+        if (isActive.value) setLoading(false)
+      }
+    },
+    [environmentId],
+  )
+
+  useEffect(() => {
+    const isActive = { value: true }
+    setLoading(true)
+    void fetchServices(isActive)
+
+    const interval = setInterval(() => {
+      void fetchServices(isActive)
+    }, POLL_INTERVAL_MS)
+
+    return () => {
+      isActive.value = false
+      clearInterval(interval)
+    }
+  }, [fetchServices, retryCounter])
+
+  return (
+    <aside className="benchmark-service-picker">
+      <div className="benchmark-service-picker-header">
+        <span className="benchmark-service-picker-title">Services</span>
+        {loading && <span className="benchmark-service-picker-loading">Loading…</span>}
+      </div>
+
+      {error ? (
+        <div className="benchmark-service-picker-error">
+          <p>{error}</p>
+          <button
+            type="button"
+            className="benchmark-service-picker-retry"
+            onClick={() => setRetryCounter((c) => c + 1)}
+          >
+            Retry
+          </button>
+        </div>
+      ) : !loading && services.length === 0 ? (
+        <p className="benchmark-service-picker-empty">No services registered.</p>
+      ) : (
+        <ul className="benchmark-service-picker-list" role="list">
+          {services.map((svc) => (
+            <li key={svc.id ?? svc.serviceName}>
+              <button
+                type="button"
+                className="benchmark-service-picker-item"
+                onClick={() => onServiceClick(svc.serviceName)}
+                title={`Insert "${svc.serviceName}"`}
+              >
+                <span className="benchmark-service-picker-item-name">{svc.serviceName}</span>
+                <span className="benchmark-service-picker-item-image">
+                  {svc.imageName ?? svc.imageSha ?? 'Unknown image'}
+                </span>
+                {copiedService === svc.serviceName && (
+                  <span className="benchmark-service-picker-copied" aria-live="polite">
+                    Copied!
+                  </span>
+                )}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </aside>
+  )
+}

--- a/src/features/benchmarks/ServicePickerPanel.tsx
+++ b/src/features/benchmarks/ServicePickerPanel.tsx
@@ -41,6 +41,10 @@ export function ServicePickerPanel({
   )
 
   useEffect(() => {
+    if (!environmentId.trim()) {
+      setLoading(false)
+      return
+    }
     const isActive = { value: true }
     setLoading(true)
     void fetchServices(isActive)
@@ -53,7 +57,7 @@ export function ServicePickerPanel({
       isActive.value = false
       clearInterval(interval)
     }
-  }, [fetchServices, retryCounter])
+  }, [fetchServices, retryCounter, environmentId])
 
   const filteredServices = searchQuery.trim()
     ? services.filter((s) =>


### PR DESCRIPTION
## Summary

Closes #79 - Adds a service picker panel beside the K6 instructions field on the create and edit benchmark forms.

## Changes

### New: `ServicePickerPanel` component
- Fetches all environment services via `getEnvironmentServices` on mount
- Polls every 30 s to stay in sync with services running on the environment
- Services sorted alphabetically by `serviceName`
- Each entry shows `serviceName` (monospace) and `imageName`/`imageSha` subtitle (fallback: *Unknown image*)
- Loading indicator, graceful error state with retry, and empty state
- Filter/search input to narrow down long service lists

### Updated: `BenchmarkFormPage`
- K6 section uses a two-column grid layout (textarea + picker); collapses to single column on narrow screens (<= 700 px)
- Clicking a service entry inserts `serviceName` at the cursor position using `document.execCommand('insertText')` -- hooks into the browser native undo stack so **Ctrl+Z / Cmd+Z works as expected**
- If the textarea has never been focused, copies to clipboard with a brief *Copied!* badge
- `onBlur` added to textarea to capture final cursor position when focus leaves

### CSS
- `.benchmark-k6-section` two-column grid layout
- `.benchmark-service-picker` panel with max-height + scroll
- `.benchmark-service-picker-search-input` filter input with focus ring
- `.benchmark-service-picker-item` full-width click targets
- `.benchmark-service-picker-copied` green badge

## Files changed
- `src/features/benchmarks/ServicePickerPanel.tsx` (new)
- `src/features/benchmarks/BenchmarkFormPage.tsx`
- `src/App.css`