### PR TITLE
feat: IDE-style K6 editor with syntax highlighting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@codemirror/lang-javascript": "^6.2.5",
+        "codemirror": "^6.0.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.13.1",
@@ -327,6 +329,102 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
+      "integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
+      "integrity": "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
+      "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.0.tgz",
+      "integrity": "sha512-ZvGm99wc/s2cITtMT15LFdn8aH/aS+V+DqyGq/N5ZlV5vWtH+nILvC2nw0zX7ByNoHHDZ2IxxdW38O0tc5nVHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.41.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.41.1.tgz",
+      "integrity": "sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.6.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@colors/colors": {
@@ -1097,6 +1195,41 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
@@ -1106,6 +1239,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
     },
     "node_modules/@nestjs/axios": {
       "version": "4.0.1",
@@ -3600,6 +3739,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3914,6 +4068,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -10955,6 +11115,12 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/super-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-1.1.0.tgz",
@@ -11715,6 +11881,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/wcwidth": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.5",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.41.1",
         "codemirror": "^6.0.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "openapi": "openapi-generator-cli generate -i ./openapi.yaml -g typescript-fetch -o ./src/generated/openapi && node -e \"const fs=require('fs'),path=require('path');function f(d){for(const e of fs.readdirSync(d)){const p=path.join(d,e);if(fs.statSync(p).isDirectory())f(p);else if(e.endsWith('.ts')){const c=fs.readFileSync(p,'utf8');if(!c.startsWith('// @ts-nocheck'))fs.writeFileSync(p,'// @ts-nocheck\\n'+c);}}}f('./src/generated/openapi')\""
   },
   "dependencies": {
+    "@codemirror/lang-javascript": "^6.2.5",
+    "codemirror": "^6.0.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.13.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   },
   "dependencies": {
     "@codemirror/lang-javascript": "^6.2.5",
+    "@codemirror/state": "^6.6.0",
+    "@codemirror/view": "^6.41.1",
     "codemirror": "^6.0.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/src/App.css
+++ b/src/App.css
@@ -1454,6 +1454,16 @@
   font-size: 0.9rem;
 }
 
+.benchmark-k6-help-link {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #4c627b;
+}
+
+.benchmark-k6-help-link a {
+  color: #1d4ed8;
+}
+
 .benchmark-form-actions {
   display: flex;
   gap: 0.6rem;
@@ -1482,9 +1492,57 @@
   min-width: 0;
 }
 
-.benchmark-k6-field .benchmark-textarea {
+.benchmark-k6-field .k6-editor {
   width: 100%;
   box-sizing: border-box;
+}
+
+.k6-editor {
+  border: 1px solid #bcc9d7;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #ffffff;
+}
+
+.k6-editor:focus-within {
+  outline: 2px solid #4895ef;
+  border-color: #4895ef;
+}
+
+.k6-editor--error {
+  border-color: #b42318;
+}
+
+.k6-editor--error:focus-within {
+  outline: 2px solid rgba(180, 35, 24, 0.2);
+  border-color: #b42318;
+}
+
+.k6-editor .cm-editor {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.95rem;
+  min-height: 220px;
+  color: #1f3347;
+}
+
+.k6-editor .cm-focused {
+  outline: none;
+}
+
+.k6-editor .cm-scroller {
+  min-height: 220px;
+  line-height: 1.45;
+}
+
+.k6-editor .cm-gutters {
+  background: #f5f8fc;
+  color: #5f738a;
+  border-right: 1px solid #d5e0ec;
+}
+
+.k6-editor .cm-activeLine,
+.k6-editor .cm-activeLineGutter {
+  background: rgba(72, 149, 239, 0.12);
 }
 
 @media (max-width: 700px) {

--- a/src/features/benchmarks/BenchmarkFormPage.tsx
+++ b/src/features/benchmarks/BenchmarkFormPage.tsx
@@ -383,7 +383,7 @@ export function BenchmarkFormPage() {
                 <a
                   href="https://grafana.com/docs/k6/latest/using-k6/"
                   target="_blank"
-                  rel="noreferrer"
+                  rel="noopener noreferrer"
                 >
                   Read the K6 documentation
                 </a>

--- a/src/features/benchmarks/BenchmarkFormPage.tsx
+++ b/src/features/benchmarks/BenchmarkFormPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent, type FormEvent } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
+import type { EditorView } from '@codemirror/view'
 import { AsyncStateView } from '../ui/async-state/AsyncState'
 import {
   createBenchmark,
@@ -11,6 +12,7 @@ import {
   UpdateBenchmarkError,
 } from './service'
 import { ServicePickerPanel } from './ServicePickerPanel'
+import { K6Editor } from './K6Editor'
 
 interface BenchmarkFormValues {
   name: string
@@ -66,9 +68,7 @@ export function BenchmarkFormPage() {
   const [loadError, setLoadError] = useState<string | null>(null)
   const [retryAttempt, setRetryAttempt] = useState(0)
 
-  // K6 textarea cursor tracking for service picker insertion
-  const k6TextareaRef = useRef<HTMLTextAreaElement>(null)
-  const k6SelectionRef = useRef<{ start: number; end: number }>({ start: 0, end: 0 })
+  const k6EditorViewRef = useRef<EditorView | null>(null)
   const k6HasFocusedRef = useRef(false)
   const [copiedService, setCopiedService] = useState<string | null>(null)
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -87,23 +87,16 @@ export function BenchmarkFormPage() {
   }, [])
 
   const insertAtCursor = useCallback((serviceName: string) => {
-    const textarea = k6TextareaRef.current
-    if (!textarea) return
-    const { start, end } = k6SelectionRef.current
-    textarea.focus()
-    textarea.setSelectionRange(start, end)
-    // Use execCommand for native undo stack (Ctrl+Z). Fall back to state
-    // splice if the command is unavailable or returns false.
-    const inserted = document.execCommand('insertText', false, serviceName)
-    if (!inserted) {
-      const next = textarea.value.slice(0, start) + serviceName + textarea.value.slice(end)
-      setValues((prev) => ({ ...prev, k6Instructions: next }))
-      setErrors((prev) => ({ ...prev, k6Instructions: undefined }))
-      setSubmitError(null)
-      const newCursor = start + serviceName.length
-      k6SelectionRef.current = { start: newCursor, end: newCursor }
-      setTimeout(() => { textarea.setSelectionRange(newCursor, newCursor) }, 0)
-    }
+    const view = k6EditorViewRef.current
+    if (!view) return
+    view.focus()
+    const selection = view.state.selection.main
+    const nextPosition = selection.from + serviceName.length
+    view.dispatch({
+      changes: { from: selection.from, to: selection.to, insert: serviceName },
+      selection: { anchor: nextPosition, head: nextPosition },
+      scrollIntoView: true,
+    })
   }, [])
 
   const handleInsertService = useCallback(
@@ -112,9 +105,11 @@ export function BenchmarkFormPage() {
         navigator.clipboard.writeText(serviceName).then(
           () => showCopiedBadge(serviceName),
           () => {
-            // Clipboard unavailable — fall back to inserting at position 0.
+            // Clipboard unavailable - fall back to inserting at position 0.
             k6HasFocusedRef.current = true
-            k6SelectionRef.current = { start: 0, end: 0 }
+            const view = k6EditorViewRef.current
+            if (!view) return
+            view.dispatch({ selection: { anchor: 0, head: 0 } })
             insertAtCursor(serviceName)
           },
         )
@@ -213,6 +208,12 @@ export function BenchmarkFormPage() {
       setErrors((prev) => ({ ...prev, [key]: undefined }))
       setSubmitError(null)
     }
+
+  const handleK6InstructionsChange = useCallback((nextValue: string) => {
+    setValues((prev) => ({ ...prev, k6Instructions: nextValue }))
+    setErrors((prev) => ({ ...prev, k6Instructions: undefined }))
+    setSubmitError(null)
+  }, [])
 
   const heading = useMemo(
     () => (isEditMode ? 'Edit benchmark' : 'Create benchmark'),
@@ -352,33 +353,21 @@ export function BenchmarkFormPage() {
               <label className="auth-label" htmlFor="benchmark-k6-instructions">
                 K6 instructions
               </label>
-              <textarea
+              <K6Editor
                 id="benchmark-k6-instructions"
-                ref={k6TextareaRef}
-                className="auth-input benchmark-textarea"
                 value={values.k6Instructions}
-                onChange={handleChange('k6Instructions')}
-                onFocus={() => {
-                  k6HasFocusedRef.current = true
+                onChange={handleK6InstructionsChange}
+                onFocusChange={(hasFocus) => {
+                  if (hasFocus) k6HasFocusedRef.current = true
                 }}
-                onSelect={(e) => {
-                  const t = e.currentTarget
-                  k6SelectionRef.current = { start: t.selectionStart, end: t.selectionEnd }
+                onEditorReady={(view) => {
+                  k6EditorViewRef.current = view
                 }}
-                onKeyUp={(e) => {
-                  const t = e.currentTarget
-                  k6SelectionRef.current = { start: t.selectionStart, end: t.selectionEnd }
-                }}
-                onBlur={(e) => {
-                  const t = e.currentTarget
-                  k6SelectionRef.current = { start: t.selectionStart, end: t.selectionEnd }
-                }}
-                aria-invalid={Boolean(errors.k6Instructions)}
-                aria-describedby={
+                disabled={isSubmitting}
+                hasError={Boolean(errors.k6Instructions)}
+                ariaDescribedBy={
                   errors.k6Instructions ? 'benchmark-k6-instructions-error' : undefined
                 }
-                disabled={isSubmitting}
-                rows={8}
               />
               {errors.k6Instructions ? (
                 <p
@@ -389,6 +378,17 @@ export function BenchmarkFormPage() {
                   {errors.k6Instructions}
                 </p>
               ) : null}
+              <p className="benchmark-k6-help-link">
+                Need help writing K6 scripts?{' '}
+                <a
+                  href="https://grafana.com/docs/k6/latest/using-k6/"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Read the K6 documentation
+                </a>
+                .
+              </p>
             </div>
             <ServicePickerPanel
               environmentId={environmentId}

--- a/src/features/benchmarks/K6Editor.tsx
+++ b/src/features/benchmarks/K6Editor.tsx
@@ -1,5 +1,5 @@
 import { basicSetup } from 'codemirror'
-import { Compartment, EditorState } from '@codemirror/state'
+import { Annotation, Compartment, EditorState, Transaction } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
 import { javascript } from '@codemirror/lang-javascript'
 import { useEffect, useRef } from 'react'
@@ -14,6 +14,8 @@ interface K6EditorProps {
   onFocusChange: (hasFocus: boolean) => void
   onEditorReady: (view: EditorView | null) => void
 }
+
+const externalSyncAnnotation = Annotation.define<boolean>()
 
 export function K6Editor({
   id,
@@ -30,6 +32,11 @@ export function K6Editor({
   const onChangeRef = useRef(onChange)
   const onFocusChangeRef = useRef(onFocusChange)
   const onEditorReadyRef = useRef(onEditorReady)
+  const idRef = useRef(id)
+  const valueRef = useRef(value)
+  const disabledRef = useRef(disabled)
+  const hasErrorRef = useRef(hasError)
+  const ariaDescribedByRef = useRef(ariaDescribedBy)
   const editableCompartmentRef = useRef(new Compartment())
   const readOnlyCompartmentRef = useRef(new Compartment())
   const contentAttributesCompartmentRef = useRef(new Compartment())
@@ -38,7 +45,12 @@ export function K6Editor({
     onChangeRef.current = onChange
     onFocusChangeRef.current = onFocusChange
     onEditorReadyRef.current = onEditorReady
-  }, [onChange, onEditorReady, onFocusChange])
+    idRef.current = id
+    valueRef.current = value
+    disabledRef.current = disabled
+    hasErrorRef.current = hasError
+    ariaDescribedByRef.current = ariaDescribedBy
+  }, [ariaDescribedBy, disabled, hasError, id, onChange, onEditorReady, onFocusChange, value])
 
   useEffect(() => {
     if (!hostRef.current) return
@@ -49,17 +61,30 @@ export function K6Editor({
 
     const editor = new EditorView({
       state: EditorState.create({
-        doc: '',
+        doc: valueRef.current,
         extensions: [
           basicSetup,
           javascript(),
           EditorView.lineWrapping,
-          editableCompartment.of(EditorView.editable.of(true)),
-          readOnlyCompartment.of(EditorState.readOnly.of(false)),
-          contentAttributesCompartment.of(EditorView.contentAttributes.of({})),
+          editableCompartment.of(EditorView.editable.of(!disabledRef.current)),
+          readOnlyCompartment.of(EditorState.readOnly.of(disabledRef.current)),
+          contentAttributesCompartment.of(
+            EditorView.contentAttributes.of({
+              id: idRef.current,
+              'aria-invalid': hasErrorRef.current ? 'true' : 'false',
+              ...(ariaDescribedByRef.current
+                ? { 'aria-describedby': ariaDescribedByRef.current }
+                : {}),
+            }),
+          ),
           EditorView.updateListener.of((update) => {
             if (update.docChanged) {
-              onChangeRef.current(update.state.doc.toString())
+              const isExternalSync = update.transactions.some(
+                (transaction) => transaction.annotation(externalSyncAnnotation) === true,
+              )
+              if (!isExternalSync) {
+                onChangeRef.current(update.state.doc.toString())
+              }
             }
             if (update.focusChanged) {
               onFocusChangeRef.current(update.view.hasFocus)
@@ -87,6 +112,7 @@ export function K6Editor({
     if (currentValue === value) return
     editor.dispatch({
       changes: { from: 0, to: currentValue.length, insert: value },
+      annotations: [Transaction.addToHistory.of(false), externalSyncAnnotation.of(true)],
     })
   }, [value])
 

--- a/src/features/benchmarks/K6Editor.tsx
+++ b/src/features/benchmarks/K6Editor.tsx
@@ -1,0 +1,123 @@
+import { basicSetup } from 'codemirror'
+import { Compartment, EditorState } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
+import { javascript } from '@codemirror/lang-javascript'
+import { useEffect, useRef } from 'react'
+
+interface K6EditorProps {
+  id: string
+  value: string
+  disabled: boolean
+  hasError: boolean
+  ariaDescribedBy?: string
+  onChange: (nextValue: string) => void
+  onFocusChange: (hasFocus: boolean) => void
+  onEditorReady: (view: EditorView | null) => void
+}
+
+export function K6Editor({
+  id,
+  value,
+  disabled,
+  hasError,
+  ariaDescribedBy,
+  onChange,
+  onFocusChange,
+  onEditorReady,
+}: K6EditorProps) {
+  const hostRef = useRef<HTMLDivElement | null>(null)
+  const viewRef = useRef<EditorView | null>(null)
+  const onChangeRef = useRef(onChange)
+  const onFocusChangeRef = useRef(onFocusChange)
+  const onEditorReadyRef = useRef(onEditorReady)
+  const editableCompartmentRef = useRef(new Compartment())
+  const readOnlyCompartmentRef = useRef(new Compartment())
+  const contentAttributesCompartmentRef = useRef(new Compartment())
+
+  useEffect(() => {
+    onChangeRef.current = onChange
+    onFocusChangeRef.current = onFocusChange
+    onEditorReadyRef.current = onEditorReady
+  }, [onChange, onEditorReady, onFocusChange])
+
+  useEffect(() => {
+    if (!hostRef.current) return
+
+    const editableCompartment = editableCompartmentRef.current
+    const readOnlyCompartment = readOnlyCompartmentRef.current
+    const contentAttributesCompartment = contentAttributesCompartmentRef.current
+
+    const editor = new EditorView({
+      state: EditorState.create({
+        doc: '',
+        extensions: [
+          basicSetup,
+          javascript(),
+          EditorView.lineWrapping,
+          editableCompartment.of(EditorView.editable.of(true)),
+          readOnlyCompartment.of(EditorState.readOnly.of(false)),
+          contentAttributesCompartment.of(EditorView.contentAttributes.of({})),
+          EditorView.updateListener.of((update) => {
+            if (update.docChanged) {
+              onChangeRef.current(update.state.doc.toString())
+            }
+            if (update.focusChanged) {
+              onFocusChangeRef.current(update.view.hasFocus)
+            }
+          }),
+        ],
+      }),
+      parent: hostRef.current,
+    })
+
+    viewRef.current = editor
+    onEditorReadyRef.current(editor)
+
+    return () => {
+      onEditorReadyRef.current(null)
+      viewRef.current = null
+      editor.destroy()
+    }
+  }, [])
+
+  useEffect(() => {
+    const editor = viewRef.current
+    if (!editor) return
+    const currentValue = editor.state.doc.toString()
+    if (currentValue === value) return
+    editor.dispatch({
+      changes: { from: 0, to: currentValue.length, insert: value },
+    })
+  }, [value])
+
+  useEffect(() => {
+    const editor = viewRef.current
+    if (!editor) return
+    editor.dispatch({
+      effects: [
+        editableCompartmentRef.current.reconfigure(EditorView.editable.of(!disabled)),
+        readOnlyCompartmentRef.current.reconfigure(EditorState.readOnly.of(disabled)),
+      ],
+    })
+  }, [disabled])
+
+  useEffect(() => {
+    const editor = viewRef.current
+    if (!editor) return
+    editor.dispatch({
+      effects: contentAttributesCompartmentRef.current.reconfigure(
+        EditorView.contentAttributes.of({
+          id,
+          'aria-invalid': hasError ? 'true' : 'false',
+          ...(ariaDescribedBy ? { 'aria-describedby': ariaDescribedBy } : {}),
+        }),
+      ),
+    })
+  }, [ariaDescribedBy, hasError, id])
+
+  return (
+    <div className={`k6-editor${hasError ? ' k6-editor--error' : ''}`}>
+      <div ref={hostRef} />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- replace the K6 textarea with a CodeMirror 6 editor
- add JavaScript syntax highlighting, line numbers, bracket matching, and editor-like styling
- keep service picker insertion at cursor using CodeMirror dispatch so Ctrl+Z works naturally
- add a K6 docs help link below the editor

Closes #81