### PR TITLE
feat(#86): Multi-host support in environment details and live monitor

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1115,15 +1115,52 @@
 }
 
 .environment-benchmarks-section h2,
-.environment-services-section h2 {
+.environment-services-section h2,
+.environment-hosts-section h2 {
   margin: 0 0 0.55rem;
   color: #1f3347;
 }
 
-.environment-services-section {
+.environment-services-section,
+.environment-hosts-section {
   margin-top: 1.75rem;
   padding-top: 0.35rem;
   border-top: 1px solid #e3ebf5;
+}
+
+.environment-hosts-empty {
+  color: #5a7a9a;
+  font-size: 0.95rem;
+  margin: 0.3rem 0;
+}
+
+.environment-hosts-table-wrap {
+  overflow-x: auto;
+}
+
+.environment-hosts-table {
+  width: 100%;
+  border-collapse: collapse;
+  border: 1px solid #d6e2f1;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.environment-hosts-table th,
+.environment-hosts-table td {
+  text-align: left;
+  padding: 0.6rem 0.7rem;
+  border-bottom: 1px solid #e3ebf5;
+  color: #1f3347;
+}
+
+.environment-hosts-table th {
+  background: #f3f8ff;
+  font-size: 0.88rem;
+}
+
+.environment-hosts-table tbody tr:last-child td {
+  border-bottom: 0;
 }
 
 .benchmark-status-badge {
@@ -1418,6 +1455,32 @@
 .run-metric-list span {
   color: #3d4b5c;
   font-size: 0.9rem;
+}
+
+.run-metric-card-count {
+  font-size: 0.85rem;
+  font-weight: normal;
+  color: #4a6a8a;
+}
+
+.run-metric-host-services {
+  list-style: none;
+  padding: 0.2rem 0 0 0.6rem;
+  margin: 0.2rem 0 0;
+  display: grid;
+  gap: 0.25rem;
+  border-left: 2px solid #d6e2f1;
+}
+
+.run-metric-host-services li {
+  display: grid;
+  gap: 0.05rem;
+}
+
+.run-metric-host-service-name {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #2f475f;
 }
 
 .benchmark-empty-cta {

--- a/src/features/benchmarks/BenchmarkRunMonitorPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunMonitorPage.tsx
@@ -598,8 +598,14 @@ export function BenchmarkRunMonitorPage() {
                   <p>No host metrics available yet.</p>
                 ) : (
                   <ul className="run-metric-list">
-                    {hostMetrics.map((host) => (
-                      <li key={`${host.hostId ?? ''}|${host.hostName ?? ''}`}>
+                     {hostMetrics.map((host, index) => (
+                      <li
+                        key={
+                          host.hostId || host.hostName
+                            ? `${host.hostId ?? ''}|${host.hostName ?? ''}`
+                            : `host-${index}`
+                        }
+                      >
                         <strong>{host.hostName ?? host.hostId ?? 'Host'}</strong>
                         <span>
                           CPU avg {formatMetric(host.resource?.cpu?.avg, '%')} | Mem avg{' '}
@@ -608,8 +614,10 @@ export function BenchmarkRunMonitorPage() {
                         </span>
                         {host.services && host.services.length > 0 && (
                           <ul className="run-metric-host-services">
-                            {host.services.map((svc) => (
-                              <li key={svc.serviceId ?? svc.serviceName ?? 'service'}>
+                            {host.services.map((svc, svcIndex) => (
+                              <li
+                                key={`${host.hostId ?? host.hostName ?? 'host'}|${svc.serviceId ?? svc.serviceName ?? `service-${svcIndex}`}`}
+                              >
                                 <span className="run-metric-host-service-name">
                                   {svc.serviceName ?? svc.serviceId ?? 'Service'}
                                 </span>

--- a/src/features/benchmarks/BenchmarkRunMonitorPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunMonitorPage.tsx
@@ -588,12 +588,17 @@ export function BenchmarkRunMonitorPage() {
               </article>
 
               <article className="run-metric-card">
-                <h3>Host resources</h3>
+                <h3>
+                  Host resources
+                  {hostMetrics.length > 1 && (
+                    <span className="run-metric-card-count"> ({hostMetrics.length} hosts)</span>
+                  )}
+                </h3>
                 {hostMetrics.length === 0 ? (
                   <p>No host metrics available yet.</p>
                 ) : (
                   <ul className="run-metric-list">
-                    {hostMetrics.slice(0, 4).map((host) => (
+                    {hostMetrics.map((host) => (
                       <li key={`${host.hostId ?? ''}|${host.hostName ?? ''}`}>
                         <strong>{host.hostName ?? host.hostId ?? 'Host'}</strong>
                         <span>
@@ -601,6 +606,21 @@ export function BenchmarkRunMonitorPage() {
                           {formatMetric(host.resource?.memory?.avg, '%')} | Net in{' '}
                           {formatBytes(host.resource?.networkInTotalBytes)}
                         </span>
+                        {host.services && host.services.length > 0 && (
+                          <ul className="run-metric-host-services">
+                            {host.services.map((svc) => (
+                              <li key={svc.serviceId ?? svc.serviceName ?? 'service'}>
+                                <span className="run-metric-host-service-name">
+                                  {svc.serviceName ?? svc.serviceId ?? 'Service'}
+                                </span>
+                                <span>
+                                  CPU avg {formatMetric(svc.resource?.cpu?.avg, '%')} | Mem avg{' '}
+                                  {formatMetric(svc.resource?.memory?.avg, '%')}
+                                </span>
+                              </li>
+                            ))}
+                          </ul>
+                        )}
                       </li>
                     ))}
                   </ul>

--- a/src/features/benchmarks/BenchmarkRunResultsPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunResultsPage.tsx
@@ -950,10 +950,7 @@ export function BenchmarkRunResultsPage() {
                   <p>Total hosts: {hostMetrics.length}</p>
                   <p>
                     Total services:{' '}
-                    {hostMetrics.reduce(
-                      (sum, host) => sum + (host.services?.length ?? 0),
-                      0,
-                    )}
+                    {rawServiceCount}
                   </p>
                 </>
               )}

--- a/src/features/environments/EnvironmentDetailsPage.tsx
+++ b/src/features/environments/EnvironmentDetailsPage.tsx
@@ -7,6 +7,7 @@ import {
   type EnvironmentRunSummaryDTO,
 } from '../../generated/openapi/models/EnvironmentRunSummaryDTO'
 import type { ServiceDTO } from '../../generated/openapi/models/ServiceDTO'
+import type { HostDTO } from '../../generated/openapi/models/HostDTO'
 import { AsyncStateView } from '../ui/async-state/AsyncState'
 import {
   listActiveEnvironmentRuns,
@@ -17,6 +18,7 @@ import {
 import {
   EnvironmentDetailsError,
   getEnvironmentDetails,
+  getEnvironmentHosts,
   getEnvironmentServices,
 } from './service'
 import { formatTimestamp } from './format'
@@ -91,6 +93,7 @@ export function EnvironmentDetailsPage() {
     Record<string, EnvironmentRunSummaryDTO>
   >({})
   const [services, setServices] = useState<Array<ServiceDTO>>([])
+  const [hosts, setHosts] = useState<Array<HostDTO> | null>(null)
   const [isBenchmarksLoading, setIsBenchmarksLoading] = useState(true)
   const [benchmarksError, setBenchmarksError] = useState<string | null>(null)
   const [isServicesLoading, setIsServicesLoading] = useState(true)
@@ -148,11 +151,12 @@ export function EnvironmentDetailsPage() {
           setIsLoading(false)
         }
 
-        const [benchmarksResult, runsResult, servicesResult] =
+        const [benchmarksResult, runsResult, servicesResult, hostsResult] =
           await Promise.allSettled([
             listBenchmarks(environmentId),
             listActiveEnvironmentRuns(environmentId),
             getEnvironmentServices(environmentId),
+            getEnvironmentHosts(environmentId),
           ])
 
         // Only update state if this request hasn't been aborted
@@ -187,6 +191,11 @@ export function EnvironmentDetailsPage() {
           setServicesError('Unable to load services right now.')
         }
         setIsServicesLoading(false)
+
+        // Handle hosts result (non-blocking; null means endpoint not yet available)
+        if (hostsResult.status === 'fulfilled') {
+          setHosts(hostsResult.value)
+        }
       } catch (nextError: unknown) {
         if (signal.aborted) {
           return
@@ -246,6 +255,14 @@ export function EnvironmentDetailsPage() {
         (a.serviceName ?? '').localeCompare(b.serviceName ?? ''),
       ),
     [services],
+  )
+
+  const sortedHosts = useMemo(
+    () =>
+      hosts
+        ? [...hosts].sort((a, b) => a.name.localeCompare(b.name))
+        : null,
+    [hosts],
   )
 
   const sortedBenchmarks = useMemo(
@@ -550,6 +567,46 @@ export function EnvironmentDetailsPage() {
             </div>
           </AsyncStateView>
         </section>
+
+        {sortedHosts !== null && (
+          <section className="environment-hosts-section">
+            <h2>Registered hosts</h2>
+            {sortedHosts.length === 0 ? (
+              <p className="environment-hosts-empty">No hosts have reported into this environment yet.</p>
+            ) : (
+              <div className="environment-hosts-table-wrap">
+                <table className="environment-hosts-table">
+                  <thead>
+                    <tr>
+                      <th>Host</th>
+                      <th>IP address</th>
+                      <th>OS</th>
+                      <th>CPU</th>
+                      <th>RAM</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {sortedHosts.map((host, index) => (
+                      <tr key={host.id ?? host.machineId ?? `host-${index}`}>
+                        <td>{host.name}</td>
+                        <td>{host.ipAddress}</td>
+                        <td>
+                          {host.os}
+                          {host.osVersion ? ` ${host.osVersion}` : ''}
+                        </td>
+                        <td>
+                          {host.cpuModel ?? 'n/a'}
+                          {host.cpuCores != null ? ` (${host.cpuCores} cores)` : ''}
+                        </td>
+                        <td>{formatMemory(host.ramTotalBytes)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+        )}
       </AsyncStateView>
     </article>
   )

--- a/src/features/environments/EnvironmentDetailsPage.tsx
+++ b/src/features/environments/EnvironmentDetailsPage.tsx
@@ -98,6 +98,7 @@ export function EnvironmentDetailsPage() {
   const [benchmarksError, setBenchmarksError] = useState<string | null>(null)
   const [isServicesLoading, setIsServicesLoading] = useState(true)
   const [servicesError, setServicesError] = useState<string | null>(null)
+  const [hostsError, setHostsError] = useState<string | null>(null)
   const [benchmarkActionError, setBenchmarkActionError] = useState<string | null>(null)
   const [startInFlightByBenchmarkId, setStartInFlightByBenchmarkId] = useState<
     Record<string, boolean>
@@ -136,6 +137,7 @@ export function EnvironmentDetailsPage() {
       }
       setBenchmarksError(null)
       setServicesError(null)
+      setHostsError(null)
       setError(null)
       setNotFound(false)
 
@@ -156,7 +158,7 @@ export function EnvironmentDetailsPage() {
             listBenchmarks(environmentId),
             listActiveEnvironmentRuns(environmentId),
             getEnvironmentServices(environmentId),
-            getEnvironmentHosts(environmentId),
+            getEnvironmentHosts(environmentId, signal),
           ])
 
         // Only update state if this request hasn't been aborted
@@ -195,6 +197,9 @@ export function EnvironmentDetailsPage() {
         // Handle hosts result (non-blocking; null means endpoint not yet available)
         if (hostsResult.status === 'fulfilled') {
           setHosts(hostsResult.value)
+        } else {
+          setHosts([])
+          setHostsError('Unable to load hosts right now.')
         }
       } catch (nextError: unknown) {
         if (signal.aborted) {
@@ -571,7 +576,9 @@ export function EnvironmentDetailsPage() {
         {sortedHosts !== null && (
           <section className="environment-hosts-section">
             <h2>Registered hosts</h2>
-            {sortedHosts.length === 0 ? (
+            {hostsError ? (
+              <p className="auth-notice auth-notice-error">{hostsError}</p>
+            ) : sortedHosts.length === 0 ? (
               <p className="environment-hosts-empty">No hosts have reported into this environment yet.</p>
             ) : (
               <div className="environment-hosts-table-wrap">

--- a/src/features/environments/service.ts
+++ b/src/features/environments/service.ts
@@ -2,9 +2,8 @@ import { ResponseError } from '../../generated/openapi/runtime'
 import type { EnvironmentDTO } from '../../generated/openapi/models/EnvironmentDTO'
 import type { ServiceDTO } from '../../generated/openapi/models/ServiceDTO'
 import { type HostDTO, HostDTOFromJSON } from '../../generated/openapi/models/HostDTO'
-import { createEnvironmentApi } from '../../auth/client'
-import { getApiBaseUrl } from '../../config/api'
-import { loadAuthSession } from '../../auth/storage'
+import { EnvironmentApi } from '../../generated/openapi/apis/EnvironmentApi'
+import { createEnvironmentApi, createApiClient } from '../../auth/client'
 
 export class EnvironmentsLoadError extends Error {
   constructor(message: string) {
@@ -150,6 +149,24 @@ export async function getEnvironmentServices(
   }
 }
 
+class EnvironmentApiWithHosts extends EnvironmentApi {
+  async listHosts(
+    { environmentId }: { environmentId: string },
+    signal?: AbortSignal,
+  ): Promise<Array<HostDTO>> {
+    const response = await this.request(
+      {
+        path: `/v1/environments/${encodeURIComponent(String(environmentId))}/hosts`,
+        method: 'GET',
+        headers: {},
+      },
+      signal ? { signal } : undefined,
+    )
+    const json = await response.json()
+    return (json as Array<unknown>).map(HostDTOFromJSON)
+  }
+}
+
 /**
  * Fetches the list of hosts registered in an environment.
  * Returns `null` when the backend endpoint is not yet available (404).
@@ -157,34 +174,23 @@ export async function getEnvironmentServices(
  */
 export async function getEnvironmentHosts(
   environmentId: string,
+  signal?: AbortSignal,
 ): Promise<Array<HostDTO> | null> {
-  const baseUrl = getApiBaseUrl()
-  const url = `${baseUrl}/v1/environments/${environmentId}/hosts`
+  const api = createApiClient(EnvironmentApiWithHosts)
 
-  const session = loadAuthSession()
-  const headers: Record<string, string> = {}
-  if (session?.token) {
-    headers['Authorization'] = `Bearer ${session.token}`
-  }
-
-  let response: Response
   try {
-    response = await fetch(url, { headers })
-  } catch {
+    return await api.listHosts({ environmentId }, signal)
+  } catch (error: unknown) {
+    if (error instanceof ResponseError) {
+      if (error.response.status === 404) {
+        return null
+      }
+      throw new EnvironmentDetailsError('Unable to load hosts right now.')
+    }
+
     throw new EnvironmentDetailsError(
       'Network error while loading hosts. Please try again.',
     )
   }
-
-  if (response.status === 404) {
-    return null
-  }
-
-  if (!response.ok) {
-    throw new EnvironmentDetailsError('Unable to load hosts right now.')
-  }
-
-  const json: unknown = await response.json()
-  return (json as Array<unknown>).map(HostDTOFromJSON)
 }
 

--- a/src/features/environments/service.ts
+++ b/src/features/environments/service.ts
@@ -1,7 +1,10 @@
 import { ResponseError } from '../../generated/openapi/runtime'
 import type { EnvironmentDTO } from '../../generated/openapi/models/EnvironmentDTO'
 import type { ServiceDTO } from '../../generated/openapi/models/ServiceDTO'
+import { type HostDTO, HostDTOFromJSON } from '../../generated/openapi/models/HostDTO'
 import { createEnvironmentApi } from '../../auth/client'
+import { getApiBaseUrl } from '../../config/api'
+import { loadAuthSession } from '../../auth/storage'
 
 export class EnvironmentsLoadError extends Error {
   constructor(message: string) {
@@ -145,5 +148,43 @@ export async function getEnvironmentServices(
       'Network error while loading services. Please try again.',
     )
   }
+}
+
+/**
+ * Fetches the list of hosts registered in an environment.
+ * Returns `null` when the backend endpoint is not yet available (404).
+ * Returns an empty array when the endpoint exists but no hosts are registered.
+ */
+export async function getEnvironmentHosts(
+  environmentId: string,
+): Promise<Array<HostDTO> | null> {
+  const baseUrl = getApiBaseUrl()
+  const url = `${baseUrl}/v1/environments/${environmentId}/hosts`
+
+  const session = loadAuthSession()
+  const headers: Record<string, string> = {}
+  if (session?.token) {
+    headers['Authorization'] = `Bearer ${session.token}`
+  }
+
+  let response: Response
+  try {
+    response = await fetch(url, { headers })
+  } catch {
+    throw new EnvironmentDetailsError(
+      'Network error while loading hosts. Please try again.',
+    )
+  }
+
+  if (response.status === 404) {
+    return null
+  }
+
+  if (!response.ok) {
+    throw new EnvironmentDetailsError('Unable to load hosts right now.')
+  }
+
+  const json: unknown = await response.json()
+  return (json as Array<unknown>).map(HostDTOFromJSON)
 }
 


### PR DESCRIPTION
## Summary

Closes #86

Implements multi-host support across the live monitor and environment details pages.

## Changes

### BenchmarkRunMonitorPage — Host resources card
- Removed the silent slice(0, 4) cap; **all hosts are now shown**
- Added an (N hosts) count label next to the heading when more than one host is present
- Renders a nested per-host service breakdown from DerivedHostSummaryDTO.services[] — shows service name, CPU avg %, and Mem avg % per service on each host

### EnvironmentDetailsPage — Registered hosts section
- Added getEnvironmentHosts() in nvironments/service.ts that calls the anticipated GET /v1/environments/{environmentId}/hosts endpoint
- Returns 
ull on 404 so the section is **silently hidden** until the backend ships the endpoint — no broken state for current users
- When the endpoint is available, renders a table showing: host name, IP address, OS + version, CPU model/cores, and total RAM

### CSS
- New .run-metric-card-count for the host count label
- New .run-metric-host-services / .run-metric-host-service-name for the nested service sub-list
- New .environment-hosts-section, .environment-hosts-table, .environment-hosts-empty for the hosts table section

## Notes
- BenchmarkRunResultsPage already handles multiple hosts correctly via awData.timeSeries.hosts[] — no changes needed there
- The agent active indicator (esolveAgentStatus) uses a scalar gentLastSeenAt field — unaffected