### PR TITLE
feat(#85): per-replica resource chart toggle and improved chart UX

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2377,6 +2377,44 @@
   color: #111827;
 }
 
+/* Custom resource chart nearest-neighbour tooltip */
+.run-resource-tooltip {
+  background: #fff;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  padding: 0.5rem 0.65rem;
+  font-size: 0.8rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+  min-width: 140px;
+}
+.run-resource-tooltip-label {
+  font-weight: 600;
+  margin-bottom: 0.3rem;
+  color: #374151;
+}
+.run-resource-tooltip-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 1px 0;
+}
+.run-resource-tooltip-swatch {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+.run-resource-tooltip-name {
+  flex: 1;
+  color: #4b5563;
+}
+.run-resource-tooltip-value {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: #111827;
+}
+
 .run-comparison-hosts {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/src/App.css
+++ b/src/App.css
@@ -2394,6 +2394,10 @@
   color: #374151;
   user-select: none;
   transition: opacity 0.15s;
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: inherit;
 }
 .run-resource-chart-legend-item--hidden {
   opacity: 0.35;

--- a/src/App.css
+++ b/src/App.css
@@ -2380,6 +2380,7 @@
 .run-resource-chart-legend {
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
   gap: 0.25rem 0.75rem;
   margin-top: 0.4rem;
   padding: 0 0.5rem;

--- a/src/App.css
+++ b/src/App.css
@@ -2028,7 +2028,6 @@
 }
 
 .run-results-resource-chart-wrap {
-  min-height: 230px;
 }
 
 .run-results-resource-chart-title {
@@ -2375,6 +2374,35 @@
   font-weight: 600;
   font-variant-numeric: tabular-nums;
   color: #111827;
+}
+
+/* Custom legend outside chart area — lets chart height stay fixed */
+.run-resource-chart-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 0.75rem;
+  margin-top: 0.4rem;
+  padding: 0 0.5rem;
+}
+.run-resource-chart-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  cursor: pointer;
+  font-size: 0.8rem;
+  color: #374151;
+  user-select: none;
+  transition: opacity 0.15s;
+}
+.run-resource-chart-legend-item--hidden {
+  opacity: 0.35;
+}
+.run-resource-chart-legend-icon {
+  flex-shrink: 0;
+  overflow: visible;
+}
+.run-resource-chart-legend-label {
+  color: #374151;
 }
 
 /* Custom resource chart nearest-neighbour tooltip */

--- a/src/features/benchmarks/BenchmarkRunResultsPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunResultsPage.tsx
@@ -144,6 +144,25 @@ const CHART_RENDER_MODE_OPTIONS: Array<{
   },
 ]
 
+type ReplicaViewMode = 'aggregated' | 'per-replica'
+
+const REPLICA_VIEW_MODE_OPTIONS: Array<{
+  value: ReplicaViewMode
+  label: string
+  description: string
+}> = [
+  {
+    value: 'aggregated',
+    label: 'Aggregated',
+    description: 'Show aggregated replica metrics per service.',
+  },
+  {
+    value: 'per-replica',
+    label: 'Per-replica',
+    description: 'Show each container replica as a separate chart series.',
+  },
+]
+
 type SeriesVisibility = Record<K6MetricKey, boolean>
 
 const DEFAULT_SERIES_VISIBILITY: SeriesVisibility = {
@@ -401,6 +420,7 @@ export function BenchmarkRunResultsPage() {
   const [resourceAxisScaleMode, setResourceAxisScaleMode] = useState<AxisScaleMode>('auto')
   const [resourceChartRenderMode, setResourceChartRenderMode] = useState<ChartRenderMode>('line')
   const [resourceSmoothingLevel, setResourceSmoothingLevel] = useState(0)
+  const [replicaViewMode, setReplicaViewMode] = useState<ReplicaViewMode>('aggregated')
   const [selectedServiceKeysByHost, setSelectedServiceKeysByHost] = useState<
     Record<string, Set<string>>
   >({})
@@ -696,14 +716,39 @@ export function BenchmarkRunResultsPage() {
         })
       }
 
-      const allServices = (host.services ?? []).map((s, serviceIndex) => ({
-        key: s.serviceId ?? s.serviceName ?? `service-${serviceIndex}`,
-        label: s.serviceName ?? s.serviceId ?? 'Service',
-        dataPoints: aggregateServiceReplicaDataPoints(s.replicas ?? []),
-      }))
+      const allServices = (host.services ?? []).map((s, serviceIndex) => {
+        const serviceKey = s.serviceId ?? s.serviceName ?? `service-${serviceIndex}`
+        const serviceLabel = s.serviceName ?? s.serviceId ?? 'Service'
+        const replicas = s.replicas ?? []
+        return {
+          key: serviceKey,
+          label: serviceLabel,
+          replicaCount: replicas.length,
+          aggregatedDataPoints: aggregateServiceReplicaDataPoints(replicas),
+          perReplicaEntities: replicas.map((r, rIndex) => ({
+            key: `${serviceKey}|r${rIndex}`,
+            label: `${serviceLabel} [${r.containerId?.slice(0, 12) ?? r.replicaId ?? `#${rIndex + 1}`}]`,
+            dataPoints: r.dataPoints ?? [],
+          })),
+        }
+      })
+
+      const hasAnyMultipleReplicas = allServices.some((s) => s.replicaCount > 1)
 
       const selectedKeys = selectedServiceKeysByHost[hostKey] ?? new Set<string>()
-      const selectedEntities = allServices.filter((s) => selectedKeys.has(s.key))
+      const selectedServiceObjects = allServices.filter((s) => selectedKeys.has(s.key))
+      const selectedEntities =
+        replicaViewMode === 'per-replica'
+          ? selectedServiceObjects.flatMap((s) =>
+              s.perReplicaEntities.length > 0
+                ? s.perReplicaEntities
+                : [{ key: s.key, label: s.label, dataPoints: s.aggregatedDataPoints }],
+            )
+          : selectedServiceObjects.map((s) => ({
+              key: s.key,
+              label: s.label,
+              dataPoints: s.aggregatedDataPoints,
+            }))
 
       const buildChart = (metrics: ResourceMetricKey[]) => {
         const data = mergeResourceSeries(selectedEntities, metrics)
@@ -803,6 +848,7 @@ export function BenchmarkRunResultsPage() {
         visibleMachinePoints,
         hasMemoryLimit,
         allServices: allServices.map((s) => ({ key: s.key, label: s.label })),
+        hasAnyMultipleReplicas,
         machineCpuDomain,
         machineMemoryDomain,
         machineMemoryLines,
@@ -822,7 +868,7 @@ export function BenchmarkRunResultsPage() {
         containerBlockLines,
       }
     })
-  }, [rawData, derivedData, selectedServiceKeysByHost, resourceSmoothingWindowSize, brushTimeRange, resourceAxisScaleMode])
+  }, [rawData, derivedData, selectedServiceKeysByHost, resourceSmoothingWindowSize, brushTimeRange, resourceAxisScaleMode, replicaViewMode])
 
   const handleToggleService = (hostKey: string, serviceKey: string) => {
     setSelectedServiceKeysByHost((current) => {
@@ -1244,6 +1290,27 @@ export function BenchmarkRunResultsPage() {
                     )
                   })}
                 </div>
+                {processedHosts.some((h) => h.hasAnyMultipleReplicas) && (
+                  <div className="run-results-axis-mode-group" role="group" aria-label="Container replica view">
+                    {REPLICA_VIEW_MODE_OPTIONS.map((option) => {
+                      const isSelected = replicaViewMode === option.value
+                      return (
+                        <button
+                          key={option.value}
+                          type="button"
+                          className={`shell-alert-dismiss run-results-axis-mode-button${
+                            isSelected ? ' is-selected' : ''
+                          }`}
+                          onClick={() => setReplicaViewMode(option.value)}
+                          aria-pressed={isSelected}
+                          title={option.description}
+                        >
+                          {option.label}
+                        </button>
+                      )
+                    })}
+                  </div>
+                )}
                 <div className="run-results-smoothing-slider-group">
                   <label
                     className="run-results-smoothing-slider-label"

--- a/src/features/benchmarks/BenchmarkRunResultsPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunResultsPage.tsx
@@ -333,6 +333,80 @@ function ResourceChart({
     })
   }, [])
 
+  const renderTooltip = useCallback(
+    (props: Record<string, unknown>) => {
+      const { active, label } = props as { active?: boolean; label?: number | string }
+      if (!active || typeof label !== 'number') return null
+
+      const resolveValue = (dataKey: string): number | null => {
+        if (data.length === 0) return null
+
+        // Binary search: find the first index at or after `label`
+        let lo = 0
+        let hi = data.length
+        while (lo < hi) {
+          const mid = (lo + hi) >> 1
+          const ts = ((data[mid] as Record<string, unknown>).timestampMs as number)
+          if (ts < label) lo = mid + 1
+          else hi = mid
+        }
+
+        let bestVal: number | null = null
+        let bestDist = Infinity
+
+        // Scan forward from lo — timestamps increase, so first non-null is the nearest forward
+        for (let i = lo; i < data.length; i++) {
+          const pt = data[i] as Record<string, unknown>
+          const dist = (pt.timestampMs as number) - label
+          if (dist >= bestDist) break
+          const v = pt[dataKey]
+          if (typeof v === 'number' && !Number.isNaN(v)) {
+            bestDist = dist
+            bestVal = v
+            break
+          }
+        }
+
+        // Scan backward from lo-1 — timestamps decrease, so first non-null is the nearest backward
+        for (let i = lo - 1; i >= 0; i--) {
+          const pt = data[i] as Record<string, unknown>
+          const dist = label - (pt.timestampMs as number)
+          if (dist >= bestDist) break
+          const v = pt[dataKey]
+          if (typeof v === 'number' && !Number.isNaN(v)) {
+            bestDist = dist
+            bestVal = v
+            break
+          }
+        }
+
+        return bestVal
+      }
+
+      const entries = lines
+        .filter((l) => !hiddenLines.has(l.dataKey))
+        .map((l) => ({ ...l, resolved: resolveValue(l.dataKey) }))
+
+      if (entries.every((e) => e.resolved === null)) return null
+
+      return (
+        <div className="run-resource-tooltip">
+          <div className="run-resource-tooltip-label">{formatChartTooltipLabel(label)}</div>
+          {entries.map((e) => (
+            <div key={e.dataKey} className="run-resource-tooltip-row">
+              <span className="run-resource-tooltip-swatch" style={{ background: e.color }} />
+              <span className="run-resource-tooltip-name">{e.name}</span>
+              <span className="run-resource-tooltip-value">
+                {e.resolved !== null ? tooltipFormatter(e.resolved, e.name)[0] : 'n/a'}
+              </span>
+            </div>
+          ))}
+        </div>
+      )
+    },
+    [data, lines, hiddenLines, tooltipFormatter],
+  )
+
   if (data.length === 0) {
     return (
       <div className="run-results-resource-chart-wrap">
@@ -364,8 +438,7 @@ function ResourceChart({
             width={68}
           />
           <Tooltip
-            formatter={tooltipFormatter}
-            labelFormatter={formatChartTooltipLabel}
+            content={renderTooltip}
             isAnimationActive={false}
           />
           <Legend onClick={handleLegendClick} />

--- a/src/features/benchmarks/BenchmarkRunResultsPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunResultsPage.tsx
@@ -440,8 +440,8 @@ function ResourceChart({
           <Tooltip
             content={renderTooltip}
             isAnimationActive={false}
+            wrapperStyle={{ zIndex: 100 }}
           />
-          <Legend onClick={handleLegendClick} />
           {lines.map((line) => (
             <Line
               key={line.dataKey}
@@ -463,6 +463,21 @@ function ResourceChart({
           ))}
         </LineChart>
       </ResponsiveContainer>
+      <div className="run-resource-chart-legend">
+        {lines.map((line) => (
+          <div
+            key={line.dataKey}
+            className={`run-resource-chart-legend-item${hiddenLines.has(line.dataKey) ? ' run-resource-chart-legend-item--hidden' : ''}`}
+            onClick={() => handleLegendClick({ dataKey: line.dataKey })}
+          >
+            <svg className="run-resource-chart-legend-icon" width="14" height="14" viewBox="0 0 14 14">
+              <line x1="0" y1="7" x2="14" y2="7" stroke={line.color} strokeWidth="2" strokeDasharray={line.strokeDasharray} />
+              <circle cx="7" cy="7" r="3" fill={line.color} />
+            </svg>
+            <span className="run-resource-chart-legend-label">{line.name}</span>
+          </div>
+        ))}
+      </div>
     </div>
   )
 }

--- a/src/features/benchmarks/BenchmarkRunResultsPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunResultsPage.tsx
@@ -154,7 +154,7 @@ const REPLICA_VIEW_MODE_OPTIONS: Array<{
   {
     value: 'aggregated',
     label: 'Aggregated',
-    description: 'Show aggregated replica metrics per service.',
+    description: 'Show summed replica metrics per service.',
   },
   {
     value: 'per-replica',
@@ -333,54 +333,47 @@ function ResourceChart({
     })
   }, [])
 
+  const seriesValueIndex = useMemo(() => {
+    const index = new Map<string, Array<{ timestampMs: number; value: number }>>()
+    for (const line of lines) {
+      index.set(line.dataKey, [])
+    }
+    for (const point of data) {
+      const record = point as Record<string, unknown>
+      const ts = record.timestampMs
+      if (typeof ts !== 'number' || Number.isNaN(ts)) continue
+      for (const line of lines) {
+        const v = record[line.dataKey]
+        if (typeof v === 'number' && !Number.isNaN(v)) {
+          index.get(line.dataKey)?.push({ timestampMs: ts, value: v })
+        }
+      }
+    }
+    return index
+  }, [data, lines])
+
   const renderTooltip = useCallback(
     (props: Record<string, unknown>) => {
       const { active, label } = props as { active?: boolean; label?: number | string }
       if (!active || typeof label !== 'number') return null
 
       const resolveValue = (dataKey: string): number | null => {
-        if (data.length === 0) return null
+        const series = seriesValueIndex.get(dataKey)
+        if (!series || series.length === 0) return null
 
-        // Binary search: find the first index at or after `label`
         let lo = 0
-        let hi = data.length
+        let hi = series.length
         while (lo < hi) {
           const mid = (lo + hi) >> 1
-          const ts = ((data[mid] as Record<string, unknown>).timestampMs as number)
-          if (ts < label) lo = mid + 1
+          if (series[mid].timestampMs < label) lo = mid + 1
           else hi = mid
         }
 
-        let bestVal: number | null = null
-        let bestDist = Infinity
-
-        // Scan forward from lo — timestamps increase, so first non-null is the nearest forward
-        for (let i = lo; i < data.length; i++) {
-          const pt = data[i] as Record<string, unknown>
-          const dist = (pt.timestampMs as number) - label
-          if (dist >= bestDist) break
-          const v = pt[dataKey]
-          if (typeof v === 'number' && !Number.isNaN(v)) {
-            bestDist = dist
-            bestVal = v
-            break
-          }
-        }
-
-        // Scan backward from lo-1 — timestamps decrease, so first non-null is the nearest backward
-        for (let i = lo - 1; i >= 0; i--) {
-          const pt = data[i] as Record<string, unknown>
-          const dist = label - (pt.timestampMs as number)
-          if (dist >= bestDist) break
-          const v = pt[dataKey]
-          if (typeof v === 'number' && !Number.isNaN(v)) {
-            bestDist = dist
-            bestVal = v
-            break
-          }
-        }
-
-        return bestVal
+        const next = lo < series.length ? series[lo] : null
+        const prev = lo > 0 ? series[lo - 1] : null
+        if (!prev) return next?.value ?? null
+        if (!next) return prev.value
+        return label - prev.timestampMs <= next.timestampMs - label ? prev.value : next.value
       }
 
       const entries = lines
@@ -404,7 +397,7 @@ function ResourceChart({
         </div>
       )
     },
-    [data, lines, hiddenLines, tooltipFormatter],
+    [seriesValueIndex, lines, hiddenLines, tooltipFormatter],
   )
 
   if (data.length === 0) {
@@ -465,17 +458,19 @@ function ResourceChart({
       </ResponsiveContainer>
       <div className="run-resource-chart-legend">
         {lines.map((line) => (
-          <div
+          <button
             key={line.dataKey}
+            type="button"
             className={`run-resource-chart-legend-item${hiddenLines.has(line.dataKey) ? ' run-resource-chart-legend-item--hidden' : ''}`}
             onClick={() => handleLegendClick({ dataKey: line.dataKey })}
+            aria-pressed={!hiddenLines.has(line.dataKey)}
           >
             <svg className="run-resource-chart-legend-icon" width="14" height="14" viewBox="0 0 14 14">
               <line x1="0" y1="7" x2="14" y2="7" stroke={line.color} strokeWidth="2" strokeDasharray={line.strokeDasharray} />
               <circle cx="7" cy="7" r="3" fill={line.color} />
             </svg>
             <span className="run-resource-chart-legend-label">{line.name}</span>
-          </div>
+          </button>
         ))}
       </div>
     </div>
@@ -813,11 +808,14 @@ export function BenchmarkRunResultsPage() {
           label: serviceLabel,
           replicaCount: replicas.length,
           aggregatedDataPoints: aggregateServiceReplicaDataPoints(replicas),
-          perReplicaEntities: replicas.map((r, rIndex) => ({
-            key: `${serviceKey}|r${rIndex}`,
-            label: `${serviceLabel} [${r.containerId?.slice(0, 12) ?? r.replicaId ?? `#${rIndex + 1}`}]`,
-            dataPoints: r.dataPoints ?? [],
-          })),
+          perReplicaEntities: replicas.map((r, rIndex) => {
+            const replicaKeyPart = r.containerId ?? r.replicaId ?? `r${rIndex}`
+            return {
+              key: `${serviceKey}|${replicaKeyPart}`,
+              label: `${serviceLabel} [${r.containerId?.slice(0, 12) ?? r.replicaId ?? `#${rIndex + 1}`}]`,
+              dataPoints: r.dataPoints ?? [],
+            }
+          }),
         }
       })
 


### PR DESCRIPTION
## Summary

Implements issue #85 — per-replica resource chart toggle — plus several UX improvements to the container resource charts.

## Changes

### Per-replica toggle
- Added \ReplicaViewMode\ type (\'aggregated'\ | \'per-replica'\) with a toggle button group in the UI
- Default view is aggregated (average across replicas); switching to per-replica shows individual replica series
- Toggle is only shown when at least one service has more than one replica
- \processedHosts\ memo extended with \eplicaCount\, \ggregatedDataPoints\, and \perReplicaEntities\

### Nearest-neighbour tooltip on resource charts
- Added a custom \enderTooltip\ to the \ResourceChart\ component (mirroring the comparison chart)
- Uses binary search + bidirectional scan to find the nearest data point per series, so all visible services always appear in the hover menu even when their measurements don't share the same timestamp

### Chart layout improvements
- Moved the Recharts \<Legend>\ outside the \<ResponsiveContainer>\ into a custom flex legend div, so the 200 px chart drawing area is fixed regardless of how many services are displayed — the parent wrapper grows to fit extra rows
- Legend items are centered under their chart and support click-to-toggle with visual dimming for hidden series
- Fixed tooltip z-index so the hover card overlaps the legend below it