### PR TITLE
fix: display memory usage as bytes instead of percentage

### DIFF
--- a/src/features/benchmarks/BenchmarkRunComparisonPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunComparisonPage.tsx
@@ -283,13 +283,13 @@ function buildMemorySummary(
       {(memA || statsA.avg != null) && (
         <div className="run-comparison-chart-summary-row">
           <span className="run-comparison-chart-summary-label run-comparison-label-a">A:</span>
-          <span>Avg {formatBytes(statsA.avg ?? undefined)} ({fmtPct(memA?.avg)}) · Max {formatBytes(statsA.max ?? undefined)} ({fmtPct(memA?.max)})</span>
+          <span>Avg {formatBytes(statsA.avg ?? undefined)} ({formatBytes(memA?.avg ?? undefined)}) · Max {formatBytes(statsA.max ?? undefined)} ({formatBytes(memA?.max ?? undefined)})</span>
         </div>
       )}
       {(memB || statsB.avg != null) && (
         <div className="run-comparison-chart-summary-row">
           <span className="run-comparison-chart-summary-label run-comparison-label-b">B:</span>
-          <span>Avg {formatBytes(statsB.avg ?? undefined)} ({fmtPct(memB?.avg)}) · Max {formatBytes(statsB.max ?? undefined)} ({fmtPct(memB?.max)})</span>
+          <span>Avg {formatBytes(statsB.avg ?? undefined)} ({formatBytes(memB?.avg ?? undefined)}) · Max {formatBytes(statsB.max ?? undefined)} ({formatBytes(memB?.max ?? undefined)})</span>
         </div>
       )}
     </div>
@@ -1323,8 +1323,8 @@ export function BenchmarkRunComparisonPage() {
                         CPU avg A: {formatMetric(host.derivedA?.resource?.cpu?.avg, '%')} B:{' '}
                         {formatMetric(host.derivedB?.resource?.cpu?.avg, '%')}
                         {' | '}
-                        Mem avg A: {formatMetric(host.derivedA?.resource?.memory?.avg, '%')} B:{' '}
-                        {formatMetric(host.derivedB?.resource?.memory?.avg, '%')}
+                        Mem avg A: {formatBytes(host.derivedA?.resource?.memory?.avg)} B:{' '}
+                        {formatBytes(host.derivedB?.resource?.memory?.avg)}
                       </span>
                     </summary>
 

--- a/src/features/benchmarks/BenchmarkRunMonitorPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunMonitorPage.tsx
@@ -609,7 +609,7 @@ export function BenchmarkRunMonitorPage() {
                         <strong>{host.hostName ?? host.hostId ?? 'Host'}</strong>
                         <span>
                           CPU avg {formatMetric(host.resource?.cpu?.avg, '%')} | Mem avg{' '}
-                          {formatMetric(host.resource?.memory?.avg, '%')} | Net in{' '}
+                          {formatBytes(host.resource?.memory?.avg)} | Net in{' '}
                           {formatBytes(host.resource?.networkInTotalBytes)}
                         </span>
                         {host.services && host.services.length > 0 && (
@@ -623,7 +623,7 @@ export function BenchmarkRunMonitorPage() {
                                 </span>
                                 <span>
                                   CPU avg {formatMetric(svc.resource?.cpu?.avg, '%')} | Mem avg{' '}
-                                  {formatMetric(svc.resource?.memory?.avg, '%')}
+                                  {formatBytes(svc.resource?.memory?.avg)}
                                 </span>
                               </li>
                             ))}

--- a/src/features/benchmarks/BenchmarkRunResultsPage.tsx
+++ b/src/features/benchmarks/BenchmarkRunResultsPage.tsx
@@ -1441,7 +1441,7 @@ export function BenchmarkRunResultsPage() {
                       <span className="run-results-host-card-name">{host.label}</span>
                       <span className="run-results-host-card-stats">
                         CPU avg {formatMetric(derivedCpu?.avg, '%')} | Mem avg{' '}
-                        {formatMetric(derivedMemory?.avg, '%')}
+                        {formatBytes(derivedMemory?.avg)}
                         {' | '}
                         Net in {formatBytes(host.derivedSummary?.resource?.networkInTotalBytes)}{' '}
                         | Net out{' '}


### PR DESCRIPTION
## Problem

Memory usage statistics were being displayed as incorrect percentage values (e.g. \10390492173.90%\) across the Results, Comparison, and Monitor pages.

## Root Cause

\DerivedResourceStatsDTO.memory.avg\ and \.max\ return **bytes**, not a percentage. However all three pages formatted these values using \ormatMetric(..., '%')\ or \mtPct()\, which simply append a \%\ suffix to the raw byte count.

## Fix

Replaced all memory avg/max formatting with \ormatBytes()\ in:

- \BenchmarkRunResultsPage.tsx\ — host card header
- \BenchmarkRunComparisonPage.tsx\ — host card header and \uildMemorySummary\ summary rows
- \BenchmarkRunMonitorPage.tsx\ — host and service inline stats

CPU formatting is unchanged — \cpu.avg\ is a genuine percentage (0–100 range) and correctly uses \ormatMetric(..., '%')\.